### PR TITLE
feat: security hardening across backend, frontend, and infrastructure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,6 @@ FROM gcr.io/distroless/static-debian12:nonroot
 
 COPY --from=builder /queue-ti /queue-ti
 COPY --from=builder /healthcheck /healthcheck
-COPY config.yaml /config.yaml
 
 EXPOSE 50051
 

--- a/README.md
+++ b/README.md
@@ -2023,6 +2023,15 @@ docker run -d \
   queue-ti:latest
 ```
 
+### gRPC TLS
+
+The gRPC server (port 50051) runs **without TLS by default**. In production, never expose port 50051 directly to untrusted networks. Use one of the following approaches:
+
+- **TLS-terminating reverse proxy** — Place an Envoy sidecar, an nginx stream proxy, or a cloud load balancer in front of port 50051 and have it handle TLS termination before forwarding plaintext gRPC to the backend.
+- **Native TLS (planned)** — A future release will support loading a certificate and key directly in the server via `QUEUETI_GRPC_TLS_CERT` / `QUEUETI_GRPC_TLS_KEY` env vars. Until then, the reverse-proxy approach is the recommended workaround for production deployments.
+
+The `docker-compose.yaml` already restricts gRPC to `127.0.0.1:50051` to prevent accidental external exposure in local and single-host environments.
+
 ### Docker Compose
 
 The included `docker-compose.yaml` orchestrates PostgreSQL, the backend, and the admin UI:

--- a/admin-ui/nginx.conf
+++ b/admin-ui/nginx.conf
@@ -8,6 +8,12 @@ server {
     # Serve pre-compressed brotli/gzip files when available
     gzip_static on;
 
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Permissions-Policy "camera=(), microphone=(), geolocation=()" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; font-src 'self';" always;
+
     location / {
         try_files $uri $uri/ /index.html;
     }

--- a/admin-ui/src/app/services/auth.service.ts
+++ b/admin-ui/src/app/services/auth.service.ts
@@ -7,6 +7,7 @@ import { tap, map, catchError } from 'rxjs/operators';
 export class AuthService {
   private http = inject(HttpClient);
 
+  // sessionStorage is intentional: cleared on tab/browser close, reducing token persistence risk vs. localStorage
   private token = signal<string | null>(sessionStorage.getItem('queueti_jwt'));
   private _authRequired = signal<boolean | null>(null);
 
@@ -17,6 +18,7 @@ export class AuthService {
     const t = this.token();
     if (!t) return null;
     try {
+      // Display-only: server validates signature on every request
       const payload = JSON.parse(atob(t.split('.')[1]));
       return typeof payload['exp'] === 'number' ? payload['exp'] * 1000 : null;
     } catch {
@@ -28,6 +30,7 @@ export class AuthService {
     const t = this.token();
     if (!t) return false;
     try {
+      // Display-only: server validates signature on every request
       const payload = JSON.parse(atob(t.split('.')[1]));
       return !!payload['adm'];
     } catch {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -77,6 +77,10 @@ func main() {
 			slog.Error("auth.enabled is true but auth.jwt_secret is not set")
 			os.Exit(1)
 		}
+		if len(cfg.Auth.JWTSecret) < 32 {
+			slog.Error("auth.jwt_secret must be at least 32 bytes for security", "length", len(cfg.Auth.JWTSecret))
+			os.Exit(1)
+		}
 		if err := users.SeedAdminUser(ctx, userStore, cfg.Auth.Username, cfg.Auth.Password); err != nil {
 			slog.Error("failed to seed admin user", "error", err)
 			os.Exit(1)
@@ -132,7 +136,7 @@ func main() {
 		}
 	}()
 
-	httpServer := server.NewHTTPServer(queueService, cfg.Auth, reg, userStore, version)
+	httpServer := server.NewHTTPServer(queueService, cfg.Server, cfg.Auth, reg, userStore, version)
 	httpAddr := fmt.Sprintf(":%d", cfg.Server.HTTPPort)
 	go func() {
 		slog.Info("HTTP server listening", "addr", httpAddr)

--- a/config.yaml
+++ b/config.yaml
@@ -7,9 +7,9 @@ db:
   host: localhost
   port: 5432
   user: postgres
-  password: postgres  # override with QUEUETI_AUTH_PASSWORD env var
+  password: postgres  # override with QUEUETI_DB_PASSWORD in production
   name: queueti
-  sslmode: disable  # override with QUEUETI_DB_SSLMODE=require in production
+  sslmode: disable  # dev only — code default is 'require'; override with QUEUETI_DB_SSLMODE
 
 queue:
   visibility_timeout: 30s
@@ -20,3 +20,4 @@ auth:
   username: admin
   password: secret
   jwt_secret: CHANGE_ME_USE_QUEUETI_AUTH_JWT_SECRET_ENV_VAR_IN_PRODUCTION
+  # cors_origins defaults to "*" — set QUEUETI_SERVER_CORS_ORIGINS to restrict in production

--- a/config.yaml
+++ b/config.yaml
@@ -1,3 +1,4 @@
+# LOCAL DEVELOPMENT ONLY — never use these values in production
 server:
   port: 50051
   http_port: 8080
@@ -6,9 +7,9 @@ db:
   host: localhost
   port: 5432
   user: postgres
-  password: postgres
+  password: postgres  # override with QUEUETI_AUTH_PASSWORD env var
   name: queueti
-  sslmode: disable
+  sslmode: disable  # override with QUEUETI_DB_SSLMODE=require in production
 
 queue:
   visibility_timeout: 30s
@@ -18,5 +19,4 @@ auth:
   enabled: false
   username: admin
   password: secret
-  jwt_secret: dev-only-secret-change-for-production
-
+  jwt_secret: CHANGE_ME_USE_QUEUETI_AUTH_JWT_SECRET_ENV_VAR_IN_PRODUCTION

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,7 +18,7 @@ services:
   queueti:
     build: .
     ports:
-      - "50051:50051"
+      - "127.0.0.1:50051:50051"
       - "8080:8080"
     environment:
       QUEUETI_DB_HOST: postgres

--- a/go.work.sum
+++ b/go.work.sum
@@ -117,6 +117,7 @@ github.com/nakagami/firebirdsql v0.0.0-20190310045651-3c02a58cfed8/go.mod h1:86w
 github.com/neo4j/neo4j-go-driver v1.8.1-0.20200803113522-b626aa943eba/go.mod h1:ncO5VaFWh0Nrt+4KT4mOZboaczBZcLuHrG+/sUeP8gI=
 github.com/onsi/ginkgo v1.16.4 h1:29JGrr5oVBm5ulCWet69zQkzWipVXIol6ygQUe/EzNc=
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
+github.com/philhofer/fwd v1.1.3-0.20240916144458-20a13a1f6b7c h1:dAMKvw0MlJT1GshSTtih8C2gDs04w8dReiOGXrGLNoY=
 github.com/philhofer/fwd v1.1.3-0.20240916144458-20a13a1f6b7c/go.mod h1:RqIHx9QI14HlwKwm98g9Re5prTQ6LdeRQn+gXJFxsJM=
 github.com/pierrec/lz4/v4 v4.1.16/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8/go.mod h1:HKlIX3XHQyzLZPlr7++PzdhaXEj94dEiJgZDTsxEqUI=
@@ -128,6 +129,7 @@ github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPO
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/snowflakedb/gosnowflake v1.6.19/go.mod h1:FM1+PWUdwB9udFDsXdfD58NONC0m+MlOSmQRvimobSM=
 github.com/spiffe/go-spiffe/v2 v2.6.0/go.mod h1:gm2SeUoMZEtpnzPNs2Csc0D/gX33k1xIx7lEzqblHEs=
+github.com/tinylib/msgp v1.2.5 h1:WeQg1whrXRFiZusidTQqzETkRpGjFjcIhW6uqWH09po=
 github.com/tinylib/msgp v1.2.5/go.mod h1:ykjzy2wzgrlvpDCRc4LA8UXy6D8bzMSuAF3WD57Gok0=
 github.com/xanzy/go-gitlab v0.15.0/go.mod h1:8zdQa/ri1dfn8eS3Ir1SyfvOKlw7WBJ8DVThkpGiXrs=
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,8 +17,9 @@ type Config struct {
 }
 
 type ServerConfig struct {
-	Port     int
-	HTTPPort int `mapstructure:"http_port"`
+	Port        int
+	HTTPPort    int    `mapstructure:"http_port"`
+	CORSOrigins string `mapstructure:"cors_origins"`
 }
 
 type DBConfig struct {
@@ -58,12 +59,13 @@ func Load() (*Config, error) {
 
 	viper.SetDefault("server.port", 50051)
 	viper.SetDefault("server.http_port", 8080)
+	viper.SetDefault("server.cors_origins", "*")
 	viper.SetDefault("db.host", "localhost")
 	viper.SetDefault("db.port", 5432)
 	viper.SetDefault("db.user", "postgres")
 	viper.SetDefault("db.password", "postgres")
 	viper.SetDefault("db.name", "queueti")
-	viper.SetDefault("db.sslmode", "disable")
+	viper.SetDefault("db.sslmode", "require")
 	viper.SetDefault("queue.visibility_timeout", "30s")
 	viper.SetDefault("queue.max_retries", 3)
 	viper.SetDefault("queue.message_ttl", "24h")
@@ -79,6 +81,7 @@ func Load() (*Config, error) {
 	// Explicitly bind environment variables to config keys
 	_ = viper.BindEnv("server.port")
 	_ = viper.BindEnv("server.http_port")
+	_ = viper.BindEnv("server.cors_origins")
 	_ = viper.BindEnv("db.host")
 	_ = viper.BindEnv("db.port")
 	_ = viper.BindEnv("db.user")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Load", func() {
 			Expect(cfg.DB.User).To(Equal("postgres"))
 			Expect(cfg.DB.Password).To(Equal("postgres"))
 			Expect(cfg.DB.Name).To(Equal("queueti"))
-			Expect(cfg.DB.SSLMode).To(Equal("disable"))
+			Expect(cfg.DB.SSLMode).To(Equal("require"))
 			Expect(cfg.Queue.VisibilityTimeout).To(Equal(30 * time.Second))
 			Expect(cfg.Queue.MaxRetries).To(Equal(3))
 			Expect(cfg.Queue.MessageTTL).To(Equal(24 * time.Hour))

--- a/internal/server/handlers_admin.go
+++ b/internal/server/handlers_admin.go
@@ -40,7 +40,7 @@ func (s *HTTPServer) purgeTopicMessages(c *fiber.Ctx) error {
 	n, err := s.queueService.PurgeTopic(c.Context(), topic, statuses)
 	if err != nil {
 		slog.Error("purge topic failed", "topic", topic, "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
 	}
 	return c.JSON(fiber.Map{"deleted": n})
 }
@@ -54,7 +54,7 @@ func (s *HTTPServer) purgeByKeyMessages(c *fiber.Ctx) error {
 	n, err := s.queueService.PurgeByKey(c.Context(), topic, key)
 	if err != nil {
 		slog.Error("purge by key failed", "topic", topic, "key", key, "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
 	}
 	return c.JSON(fiber.Map{"deleted": n})
 }
@@ -63,7 +63,7 @@ func (s *HTTPServer) runExpiryReaperOnce(c *fiber.Ctx) error {
 	n, err := s.queueService.RunExpiryReaperOnce(c.Context())
 	if err != nil {
 		slog.Error("expiry reaper (manual) failed", "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
 	}
 	return c.JSON(fiber.Map{"expired": n})
 }
@@ -72,7 +72,7 @@ func (s *HTTPServer) runDeleteReaperOnce(c *fiber.Ctx) error {
 	n, err := s.queueService.RunDeleteReaperOnce(c.Context())
 	if err != nil {
 		slog.Error("delete reaper (manual) failed", "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
 	}
 	return c.JSON(fiber.Map{"deleted": n})
 }
@@ -80,7 +80,8 @@ func (s *HTTPServer) runDeleteReaperOnce(c *fiber.Ctx) error {
 func (s *HTTPServer) getDeleteReaperSchedule(c *fiber.Ctx) error {
 	schedule, err := s.queueService.GetDeleteReaperSchedule(c.Context())
 	if err != nil {
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+		slog.Error("get delete reaper schedule failed", "error", err)
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
 	}
 	return c.JSON(fiber.Map{"schedule": schedule, "active": schedule != ""})
 }

--- a/internal/server/handlers_messages.go
+++ b/internal/server/handlers_messages.go
@@ -104,7 +104,7 @@ func (s *HTTPServer) listMessages(c *fiber.Ctx) error {
 	messages, total, err := s.queueService.List(c.Context(), topic, limit, offset)
 	if err != nil {
 		slog.Error("list messages failed", "topic", topic, "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	items := make([]messageResponse, 0, len(messages))
@@ -142,7 +142,7 @@ func (s *HTTPServer) enqueueMessage(c *fiber.Ctx) error {
 			return c.Status(fiber.StatusTooManyRequests).JSON(fiber.Map{"error": err.Error()})
 		}
 		slog.Error("enqueue failed", "topic", req.Topic, "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	return c.Status(fiber.StatusCreated).JSON(fiber.Map{"id": id})
@@ -177,7 +177,7 @@ func (s *HTTPServer) batchDequeueMessages(c *fiber.Ctx) error {
 			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": err.Error()})
 		}
 		slog.Error("batch dequeue failed", "topic", req.Topic, "count", req.Count, "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	items := make([]messageResponse, 0, len(batch))
@@ -200,7 +200,7 @@ func (s *HTTPServer) nackMessage(c *fiber.Ctx) error {
 			return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": err.Error()})
 		}
 		slog.Error("nack failed", "id", id, "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	return c.SendStatus(fiber.StatusNoContent)
@@ -210,7 +210,7 @@ func (s *HTTPServer) statsHandler(c *fiber.Ctx) error {
 	stats, err := s.queueService.Stats(c.Context())
 	if err != nil {
 		slog.Error("stats failed", "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
 	}
 	items := make([]topicStatResponse, len(stats))
 	for i, st := range stats {
@@ -227,7 +227,7 @@ func (s *HTTPServer) requeueMessage(c *fiber.Ctx) error {
 			return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": err.Error()})
 		}
 		slog.Error("requeue failed", "id", id, "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	return c.SendStatus(fiber.StatusNoContent)

--- a/internal/server/handlers_replay.go
+++ b/internal/server/handlers_replay.go
@@ -62,7 +62,7 @@ func (s *HTTPServer) replayTopic(c *fiber.Ctx) error {
 			return c.Status(fiber.StatusUnprocessableEntity).JSON(fiber.Map{"error": err.Error()})
 		}
 		slog.Error("replay topic failed", "topic", topic, "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	fromStr := ""
@@ -86,7 +86,7 @@ func (s *HTTPServer) listMessageLog(c *fiber.Ctx) error {
 	msgs, total, err := s.queueService.ListMessageLog(c.Context(), topic, limit, offset)
 	if err != nil {
 		slog.Error("list message log failed", "topic", topic, "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
 	}
 
 	items := make([]archivedMessageResponse, len(msgs))
@@ -109,7 +109,7 @@ func (s *HTTPServer) runArchiveReaperOnce(c *fiber.Ctx) error {
 	n, err := s.queueService.RunArchiveReaperOnce(c.Context())
 	if err != nil {
 		slog.Error("archive reaper (manual) failed", "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
 	}
 	return c.JSON(fiber.Map{"deleted": n})
 }
@@ -128,7 +128,7 @@ func (s *HTTPServer) trimMessageLog(c *fiber.Ctx) error {
 	n, err := s.queueService.TrimMessageLog(c.Context(), topic, before)
 	if err != nil {
 		slog.Error("trim message log failed", "topic", topic, "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
 	}
 	return c.JSON(fiber.Map{"deleted": n})
 }

--- a/internal/server/handlers_topic_config.go
+++ b/internal/server/handlers_topic_config.go
@@ -49,7 +49,7 @@ func (s *HTTPServer) listTopicConfigs(c *fiber.Ctx) error {
 	configs, err := s.queueService.ListTopicConfigs(c.Context())
 	if err != nil {
 		slog.Error("list topic configs failed", "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
 	}
 	items := make([]topicConfigResponse, len(configs))
 	for i, cfg := range configs {
@@ -92,7 +92,7 @@ func (s *HTTPServer) upsertTopicConfig(c *fiber.Ctx) error {
 	}
 	if err := s.queueService.UpsertTopicConfig(c.Context(), cfg); err != nil {
 		slog.Error("upsert topic config failed", "topic", topic, "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
 	}
 	return c.JSON(toTopicConfigResponse(cfg))
 }
@@ -104,7 +104,7 @@ func (s *HTTPServer) deleteTopicConfig(c *fiber.Ctx) error {
 			return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": err.Error()})
 		}
 		slog.Error("delete topic config failed", "topic", topic, "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
 	}
 	return c.SendStatus(fiber.StatusNoContent)
 }

--- a/internal/server/handlers_topic_schema.go
+++ b/internal/server/handlers_topic_schema.go
@@ -37,7 +37,7 @@ func (s *HTTPServer) listTopicSchemas(c *fiber.Ctx) error {
 	schemas, err := queue.ListTopicSchemas(c.Context(), s.queueService.Pool())
 	if err != nil {
 		slog.Error("list topic schemas failed", "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
 	}
 	items := make([]topicSchemaResponse, len(schemas))
 	for i, ts := range schemas {
@@ -60,7 +60,7 @@ func (s *HTTPServer) upsertTopicSchema(c *fiber.Ctx) error {
 			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": err.Error()})
 		}
 		slog.Error("upsert topic schema failed", "topic", topic, "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
 	}
 	return c.JSON(toTopicSchemaResponse(*ts))
 }
@@ -69,7 +69,7 @@ func (s *HTTPServer) deleteTopicSchema(c *fiber.Ctx) error {
 	topic := c.Params("topic")
 	if err := queue.DeleteTopicSchema(c.Context(), s.queueService.Pool(), topic); err != nil {
 		slog.Error("delete topic schema failed", "topic", topic, "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
 	}
 	return c.SendStatus(fiber.StatusNoContent)
 }
@@ -79,7 +79,7 @@ func (s *HTTPServer) getTopicSchema(c *fiber.Ctx) error {
 	ts, err := queue.GetTopicSchema(c.Context(), s.queueService.Pool(), topic)
 	if err != nil {
 		slog.Error("get topic schema failed", "topic", topic, "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
 	}
 	if ts == nil {
 		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": "schema not found"})

--- a/internal/server/handlers_users.go
+++ b/internal/server/handlers_users.go
@@ -67,7 +67,7 @@ func (s *HTTPServer) listUsers(c *fiber.Ctx) error {
 	list, err := s.userStore.List(c.Context())
 	if err != nil {
 		slog.Error("list users failed", "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
 	}
 	items := make([]userResponse, len(list))
 	for i, u := range list {
@@ -84,13 +84,16 @@ func (s *HTTPServer) createUser(c *fiber.Ctx) error {
 	if req.Username == "" || req.Password == "" {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "username and password are required"})
 	}
+	if len(req.Password) < 12 {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "password must be at least 12 characters"})
+	}
 	u, err := s.userStore.Create(c.Context(), req.Username, req.Password, req.IsAdmin)
 	if errors.Is(err, users.ErrDuplicate) {
 		return c.Status(fiber.StatusConflict).JSON(fiber.Map{"error": err.Error()})
 	}
 	if err != nil {
 		slog.Error("create user failed", "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
 	}
 	return c.Status(fiber.StatusCreated).JSON(toUserResponse(u))
 }
@@ -101,6 +104,9 @@ func (s *HTTPServer) updateUser(c *fiber.Ctx) error {
 	if err := c.BodyParser(&req); err != nil {
 		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid request body"})
 	}
+	if req.Password != nil && len(*req.Password) < 12 {
+		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "password must be at least 12 characters"})
+	}
 	u, err := s.userStore.Update(c.Context(), id, req.Username, req.Password, req.IsAdmin)
 	if errors.Is(err, users.ErrNotFound) {
 		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": err.Error()})
@@ -110,7 +116,7 @@ func (s *HTTPServer) updateUser(c *fiber.Ctx) error {
 	}
 	if err != nil {
 		slog.Error("update user failed", "id", id, "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
 	}
 	return c.JSON(toUserResponse(u))
 }
@@ -130,7 +136,7 @@ func (s *HTTPServer) deleteUser(c *fiber.Ctx) error {
 	}
 	if err != nil {
 		slog.Error("delete user failed", "id", id, "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
 	}
 	return c.SendStatus(fiber.StatusNoContent)
 }
@@ -140,7 +146,7 @@ func (s *HTTPServer) listUserGrants(c *fiber.Ctx) error {
 	grants, err := s.userStore.ListGrants(c.Context(), userID)
 	if err != nil {
 		slog.Error("list user grants failed", "user_id", userID, "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
 	}
 	items := make([]grantResponse, len(grants))
 	for i, g := range grants {
@@ -165,7 +171,7 @@ func (s *HTTPServer) addUserGrant(c *fiber.Ctx) error {
 	g, err := s.userStore.AddGrant(c.Context(), userID, req.Action, topicPattern)
 	if err != nil {
 		slog.Error("add user grant failed", "user_id", userID, "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
 	}
 	return c.Status(fiber.StatusCreated).JSON(toGrantResponse(g))
 }
@@ -179,7 +185,7 @@ func (s *HTTPServer) deleteUserGrant(c *fiber.Ctx) error {
 	}
 	if err != nil {
 		slog.Error("delete user grant failed", "user_id", userID, "grant_id", grantID, "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": err.Error()})
+		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
 	}
 	return c.SendStatus(fiber.StatusNoContent)
 }

--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/gofiber/fiber/v2"
 	"github.com/gofiber/fiber/v2/middleware/cors"
+	"github.com/gofiber/fiber/v2/middleware/limiter"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/valyala/fasthttp/fasthttpadaptor"
@@ -21,14 +22,16 @@ type HTTPServer struct {
 	App          *fiber.App
 	queueService *queue.Service
 	authConfig   config.AuthConfig
+	serverConfig config.ServerConfig
 	userStore    *users.Store
 	version      string
 }
 
-func NewHTTPServer(qs *queue.Service, authCfg config.AuthConfig, gatherer prometheus.Gatherer, userStore *users.Store, version string) *HTTPServer {
+func NewHTTPServer(qs *queue.Service, serverCfg config.ServerConfig, authCfg config.AuthConfig, gatherer prometheus.Gatherer, userStore *users.Store, version string) *HTTPServer {
 	s := &HTTPServer{
 		queueService: qs,
 		authConfig:   authCfg,
+		serverConfig: serverCfg,
 		userStore:    userStore,
 		version:      version,
 	}
@@ -38,7 +41,7 @@ func NewHTTPServer(qs *queue.Service, authCfg config.AuthConfig, gatherer promet
 	})
 
 	app.Use(cors.New(cors.Config{
-		AllowOrigins: "*",
+		AllowOrigins: serverCfg.CORSOrigins,
 		AllowMethods: "GET,POST,PUT,DELETE,OPTIONS",
 		AllowHeaders: "Content-Type,Authorization",
 	}))
@@ -60,14 +63,6 @@ func NewHTTPServer(qs *queue.Service, authCfg config.AuthConfig, gatherer promet
 		return c.SendStatus(fiber.StatusOK)
 	})
 
-	promH := fasthttpadaptor.NewFastHTTPHandler(
-		promhttp.HandlerFor(gatherer, promhttp.HandlerOpts{}),
-	)
-	app.Get("/metrics", func(c *fiber.Ctx) error {
-		promH(c.Context())
-		return nil
-	})
-
 	var jwtAuth fiber.Handler
 	if authCfg.Enabled {
 		jwtAuth = internalAuth.JWTMiddleware([]byte(authCfg.JWTSecret))
@@ -75,10 +70,23 @@ func NewHTTPServer(qs *queue.Service, authCfg config.AuthConfig, gatherer promet
 		jwtAuth = func(c *fiber.Ctx) error { return c.Next() }
 	}
 
+	promH := fasthttpadaptor.NewFastHTTPHandler(
+		promhttp.HandlerFor(gatherer, promhttp.HandlerOpts{}),
+	)
+	app.Get("/metrics", jwtAuth, func(c *fiber.Ctx) error {
+		promH(c.Context())
+		return nil
+	})
+
+	loginLimiter := limiter.New(limiter.Config{
+		Max:        10,
+		Expiration: 60 * time.Second,
+	})
+
 	api := app.Group("/api")
 	api.Get("/version", s.versionHandler)
 	api.Get("/auth/status", s.authStatus)
-	api.Post("/auth/login", s.handleLogin)
+	api.Post("/auth/login", loginLimiter, s.handleLogin)
 	api.Post("/auth/refresh", jwtAuth, s.handleRefresh)
 
 	userRoutes := api.Group("/users", jwtAuth, s.requireAdmin())

--- a/internal/server/http_test.go
+++ b/internal/server/http_test.go
@@ -106,7 +106,7 @@ var _ = Describe("HTTP Server", func() {
 		Context("Given the server is running", func() {
 			It("should return HTTP 200", func() {
 				// Given the HTTP server with auth disabled
-				httpServer := server.NewHTTPServer(queueService, config.AuthConfig{Enabled: false}, prometheus.NewRegistry(), nil, "dev")
+				httpServer := server.NewHTTPServer(queueService, config.ServerConfig{CORSOrigins: "*"}, config.AuthConfig{Enabled: false}, prometheus.NewRegistry(), nil, "dev")
 
 				// When we call the health endpoint
 				req := httptest.NewRequest("GET", "/healthz", nil)
@@ -126,7 +126,7 @@ var _ = Describe("HTTP Server", func() {
 	Describe("GET /api/version", func() {
 		Context("Given the server is running", func() {
 			It("should return the version string injected at construction", func() {
-				httpServer := server.NewHTTPServer(queueService, config.AuthConfig{Enabled: false}, prometheus.NewRegistry(), nil, "v1.2.3")
+				httpServer := server.NewHTTPServer(queueService, config.ServerConfig{CORSOrigins: "*"}, config.AuthConfig{Enabled: false}, prometheus.NewRegistry(), nil, "v1.2.3")
 
 				req := httptest.NewRequest("GET", "/api/version", nil)
 				resp, err := httpServer.App.Test(req)
@@ -149,7 +149,7 @@ var _ = Describe("HTTP Server", func() {
 		Context("Given auth is disabled", func() {
 			It("should return auth_required: false", func() {
 				// Given the HTTP server with auth disabled
-				httpServer := server.NewHTTPServer(queueService, config.AuthConfig{Enabled: false}, prometheus.NewRegistry(), nil, "dev")
+				httpServer := server.NewHTTPServer(queueService, config.ServerConfig{CORSOrigins: "*"}, config.AuthConfig{Enabled: false}, prometheus.NewRegistry(), nil, "dev")
 
 				// When we call the auth status endpoint
 				req := httptest.NewRequest("GET", "/api/auth/status", nil)
@@ -168,7 +168,7 @@ var _ = Describe("HTTP Server", func() {
 		Context("Given auth is enabled", func() {
 			It("should return auth_required: true", func() {
 				// Given the HTTP server with auth enabled
-				httpServer := server.NewHTTPServer(queueService, config.AuthConfig{
+				httpServer := server.NewHTTPServer(queueService, config.ServerConfig{CORSOrigins: "*"}, config.AuthConfig{
 					Enabled:   true,
 					JWTSecret: testJWTSecret,
 				}, prometheus.NewRegistry(), userStore, "dev")
@@ -196,7 +196,7 @@ var _ = Describe("HTTP Server", func() {
 		var httpServer *server.HTTPServer
 
 		BeforeEach(func() {
-			httpServer = server.NewHTTPServer(queueService, config.AuthConfig{
+			httpServer = server.NewHTTPServer(queueService, config.ServerConfig{CORSOrigins: "*"}, config.AuthConfig{
 				Enabled:   true,
 				JWTSecret: testJWTSecret,
 			}, prometheus.NewRegistry(), userStore, "dev")
@@ -205,7 +205,7 @@ var _ = Describe("HTTP Server", func() {
 		Context("Given auth is disabled", func() {
 			It("should pass the request through without an Authorization header", func() {
 				// Given the HTTP server with auth disabled
-				noAuthServer := server.NewHTTPServer(queueService, config.AuthConfig{Enabled: false}, prometheus.NewRegistry(), nil, "dev")
+				noAuthServer := server.NewHTTPServer(queueService, config.ServerConfig{CORSOrigins: "*"}, config.AuthConfig{Enabled: false}, prometheus.NewRegistry(), nil, "dev")
 
 				// When we call a protected endpoint without credentials
 				req := httptest.NewRequest("GET", "/api/messages", nil)
@@ -287,7 +287,7 @@ var _ = Describe("HTTP Server", func() {
 		var httpServer *server.HTTPServer
 
 		BeforeEach(func() {
-			httpServer = server.NewHTTPServer(queueService, config.AuthConfig{
+			httpServer = server.NewHTTPServer(queueService, config.ServerConfig{CORSOrigins: "*"}, config.AuthConfig{
 				Enabled:   true,
 				JWTSecret: testJWTSecret,
 			}, prometheus.NewRegistry(), userStore, "dev")
@@ -371,7 +371,7 @@ var _ = Describe("HTTP Server", func() {
 		var httpServer *server.HTTPServer
 
 		BeforeEach(func() {
-			httpServer = server.NewHTTPServer(queueService, config.AuthConfig{
+			httpServer = server.NewHTTPServer(queueService, config.ServerConfig{CORSOrigins: "*"}, config.AuthConfig{
 				Enabled:   true,
 				JWTSecret: testJWTSecret,
 			}, prometheus.NewRegistry(), userStore, "dev")
@@ -432,7 +432,7 @@ var _ = Describe("HTTP Server", func() {
 		}
 
 		BeforeEach(func() {
-			httpServer = server.NewHTTPServer(queueService, authCfg, prometheus.NewRegistry(), userStore, "dev")
+			httpServer = server.NewHTTPServer(queueService, config.ServerConfig{CORSOrigins: "*"}, authCfg, prometheus.NewRegistry(), userStore, "dev")
 		})
 
 		Context("when an admin user makes requests", func() {
@@ -531,7 +531,7 @@ var _ = Describe("HTTP Server", func() {
 		var httpServer *server.HTTPServer
 
 		BeforeEach(func() {
-			httpServer = server.NewHTTPServer(queueService, config.AuthConfig{Enabled: false}, prometheus.NewRegistry(), nil, "dev")
+			httpServer = server.NewHTTPServer(queueService, config.ServerConfig{CORSOrigins: "*"}, config.AuthConfig{Enabled: false}, prometheus.NewRegistry(), nil, "dev")
 		})
 
 		Context("Given no messages exist", func() {
@@ -628,7 +628,7 @@ var _ = Describe("HTTP Server", func() {
 				admin, err := us.Create(httpTestCtx, "msg-admin", "secret", true)
 				Expect(err).NotTo(HaveOccurred())
 
-				authServer := server.NewHTTPServer(queueService, config.AuthConfig{
+				authServer := server.NewHTTPServer(queueService, config.ServerConfig{CORSOrigins: "*"}, config.AuthConfig{
 					Enabled:   true,
 					JWTSecret: testJWTSecret,
 				}, prometheus.NewRegistry(), us, "dev")
@@ -662,7 +662,7 @@ var _ = Describe("HTTP Server", func() {
 		var httpServer *server.HTTPServer
 
 		BeforeEach(func() {
-			httpServer = server.NewHTTPServer(queueService, config.AuthConfig{Enabled: false}, prometheus.NewRegistry(), nil, "dev")
+			httpServer = server.NewHTTPServer(queueService, config.ServerConfig{CORSOrigins: "*"}, config.AuthConfig{Enabled: false}, prometheus.NewRegistry(), nil, "dev")
 		})
 
 		Context("Given the request body is not valid JSON", func() {
@@ -787,7 +787,7 @@ var _ = Describe("HTTP Server", func() {
 				adminToken, err = users.IssueToken([]byte(testJWTSecret), admin.ID, admin.Username, admin.IsAdmin)
 				Expect(err).NotTo(HaveOccurred())
 
-				authServer = server.NewHTTPServer(queueService, config.AuthConfig{
+				authServer = server.NewHTTPServer(queueService, config.ServerConfig{CORSOrigins: "*"}, config.AuthConfig{
 					Enabled:   true,
 					JWTSecret: testJWTSecret,
 				}, prometheus.NewRegistry(), us, "dev")
@@ -828,7 +828,7 @@ var _ = Describe("HTTP Server", func() {
 			It("should return 422", func() {
 				// Given a service with topic registration enforcement and no topic_config row.
 				strictService := queue.NewService(httpTestPool, 30*time.Second, 3, 0, 3, true, queue.NoopRecorder{})
-				strictServer := server.NewHTTPServer(strictService, config.AuthConfig{Enabled: false}, prometheus.NewRegistry(), nil, "dev")
+				strictServer := server.NewHTTPServer(strictService, config.ServerConfig{CORSOrigins: "*"}, config.AuthConfig{Enabled: false}, prometheus.NewRegistry(), nil, "dev")
 
 				req := httptest.NewRequest("POST", "/api/messages",
 					strings.NewReader(`{"topic":"unknown-topic","payload":"hello"}`))
@@ -848,7 +848,7 @@ var _ = Describe("HTTP Server", func() {
 					Topic: "known-topic",
 				})).To(Succeed())
 
-				strictServer := server.NewHTTPServer(strictService, config.AuthConfig{Enabled: false}, prometheus.NewRegistry(), nil, "dev")
+				strictServer := server.NewHTTPServer(strictService, config.ServerConfig{CORSOrigins: "*"}, config.AuthConfig{Enabled: false}, prometheus.NewRegistry(), nil, "dev")
 
 				req := httptest.NewRequest("POST", "/api/messages",
 					strings.NewReader(`{"topic":"known-topic","payload":"hello"}`))
@@ -957,7 +957,7 @@ var _ = Describe("HTTP Server", func() {
 			userToken, err = users.IssueToken([]byte(testJWTSecret), nonAdmin.ID, nonAdmin.Username, nonAdmin.IsAdmin)
 			Expect(err).NotTo(HaveOccurred())
 
-			httpServer = server.NewHTTPServer(queueService, config.AuthConfig{
+			httpServer = server.NewHTTPServer(queueService, config.ServerConfig{CORSOrigins: "*"}, config.AuthConfig{
 				Enabled:   true,
 				JWTSecret: testJWTSecret,
 			}, prometheus.NewRegistry(), userStore, "dev")
@@ -1017,7 +1017,7 @@ var _ = Describe("HTTP Server", func() {
 		var httpServer *server.HTTPServer
 
 		BeforeEach(func() {
-			httpServer = server.NewHTTPServer(queueService, config.AuthConfig{Enabled: false}, prometheus.NewRegistry(), nil, "dev")
+			httpServer = server.NewHTTPServer(queueService, config.ServerConfig{CORSOrigins: "*"}, config.AuthConfig{Enabled: false}, prometheus.NewRegistry(), nil, "dev")
 		})
 
 		Context("Given a message that has been promoted to the DLQ", func() {
@@ -1026,7 +1026,7 @@ var _ = Describe("HTTP Server", func() {
 			BeforeEach(func() {
 				// Use dlqThreshold = 1 so a single nack promotes the message.
 				dlqService := queue.NewService(httpTestPool, 30*time.Second, 5, 0, 1, false, queue.NoopRecorder{})
-				httpServer = server.NewHTTPServer(dlqService, config.AuthConfig{Enabled: false}, prometheus.NewRegistry(), nil, "dev")
+				httpServer = server.NewHTTPServer(dlqService, config.ServerConfig{CORSOrigins: "*"}, config.AuthConfig{Enabled: false}, prometheus.NewRegistry(), nil, "dev")
 
 				var err error
 				dlqMessageID, err = dlqService.Enqueue(httpTestCtx, "payments", []byte("charge"), nil, nil)
@@ -1081,19 +1081,19 @@ var _ = Describe("HTTP Server", func() {
 			reg = prometheus.NewRegistry()
 			rec := metrics.New(httpTestPool, reg)
 			svc := queue.NewService(httpTestPool, 30*time.Second, 3, 0, 3, false, rec)
-			httpServer = server.NewHTTPServer(svc, config.AuthConfig{
+			httpServer = server.NewHTTPServer(svc, config.ServerConfig{CORSOrigins: "*"}, config.AuthConfig{
 				Enabled:   true,
 				JWTSecret: testJWTSecret,
 			}, reg, userStore, "dev")
 		})
 
 		Context("when called without an Authorization header and auth is enabled", func() {
-			It("should return 200 OK — metrics are always public", func() {
+			It("should return 401 — metrics are protected by JWT middleware", func() {
 				req := httptest.NewRequest("GET", "/metrics", nil)
 				resp, err := httpServer.App.Test(req)
 
 				Expect(err).NotTo(HaveOccurred())
-				Expect(resp.StatusCode).To(Equal(200))
+				Expect(resp.StatusCode).To(Equal(401))
 			})
 		})
 
@@ -1103,7 +1103,7 @@ var _ = Describe("HTTP Server", func() {
 				reg2 := prometheus.NewRegistry()
 				rec2 := metrics.New(httpTestPool, reg2)
 				svc2 := queue.NewService(httpTestPool, 30*time.Second, 3, 0, 3, false, rec2)
-				httpServer = server.NewHTTPServer(svc2, config.AuthConfig{Enabled: false}, reg2, nil, "dev")
+				httpServer = server.NewHTTPServer(svc2, config.ServerConfig{CORSOrigins: "*"}, config.AuthConfig{Enabled: false}, reg2, nil, "dev")
 
 				_, err := svc2.Enqueue(httpTestCtx, "metrics-topic", []byte("hello"), nil, nil)
 				Expect(err).NotTo(HaveOccurred())
@@ -1144,7 +1144,7 @@ var _ = Describe("HTTP Server", func() {
 		const paginationTopic = "pagination-topic"
 
 		BeforeEach(func() {
-			httpServer = server.NewHTTPServer(queueService, config.AuthConfig{Enabled: false}, prometheus.NewRegistry(), nil, "dev")
+			httpServer = server.NewHTTPServer(queueService, config.ServerConfig{CORSOrigins: "*"}, config.AuthConfig{Enabled: false}, prometheus.NewRegistry(), nil, "dev")
 
 			// Given 5 messages are enqueued on the same topic
 			for i := range 5 {
@@ -1248,7 +1248,7 @@ var _ = Describe("HTTP Server", func() {
 		BeforeEach(func() {
 			_, err := httpTestPool.Exec(httpTestCtx, "DELETE FROM topic_config")
 			Expect(err).NotTo(HaveOccurred())
-			httpServer = server.NewHTTPServer(queueService, config.AuthConfig{Enabled: false}, prometheus.NewRegistry(), nil, "dev")
+			httpServer = server.NewHTTPServer(queueService, config.ServerConfig{CORSOrigins: "*"}, config.AuthConfig{Enabled: false}, prometheus.NewRegistry(), nil, "dev")
 		})
 
 		Context("when no topic configs exist", func() {
@@ -1303,7 +1303,7 @@ var _ = Describe("HTTP Server", func() {
 		BeforeEach(func() {
 			_, err := httpTestPool.Exec(httpTestCtx, "DELETE FROM topic_config")
 			Expect(err).NotTo(HaveOccurred())
-			httpServer = server.NewHTTPServer(queueService, config.AuthConfig{Enabled: false}, prometheus.NewRegistry(), nil, "dev")
+			httpServer = server.NewHTTPServer(queueService, config.ServerConfig{CORSOrigins: "*"}, config.AuthConfig{Enabled: false}, prometheus.NewRegistry(), nil, "dev")
 		})
 
 		Context("when a valid body is provided", func() {
@@ -1339,7 +1339,7 @@ var _ = Describe("HTTP Server", func() {
 
 		Context("when no Authorization header is provided and auth is enabled", func() {
 			It("should return 401", func() {
-				authServer := server.NewHTTPServer(queueService, config.AuthConfig{
+				authServer := server.NewHTTPServer(queueService, config.ServerConfig{CORSOrigins: "*"}, config.AuthConfig{
 					Enabled:   true,
 					JWTSecret: testJWTSecret,
 				}, prometheus.NewRegistry(), userStore, "dev")
@@ -1365,7 +1365,7 @@ var _ = Describe("HTTP Server", func() {
 		BeforeEach(func() {
 			_, err := httpTestPool.Exec(httpTestCtx, "DELETE FROM topic_config")
 			Expect(err).NotTo(HaveOccurred())
-			httpServer = server.NewHTTPServer(queueService, config.AuthConfig{Enabled: false}, prometheus.NewRegistry(), nil, "dev")
+			httpServer = server.NewHTTPServer(queueService, config.ServerConfig{CORSOrigins: "*"}, config.AuthConfig{Enabled: false}, prometheus.NewRegistry(), nil, "dev")
 		})
 
 		Context("when the topic config exists", func() {
@@ -1405,7 +1405,7 @@ var _ = Describe("HTTP Server", func() {
 		BeforeEach(func() {
 			_, err := httpTestPool.Exec(httpTestCtx, "DELETE FROM topic_config")
 			Expect(err).NotTo(HaveOccurred())
-			httpServer = server.NewHTTPServer(queueService, config.AuthConfig{Enabled: false}, prometheus.NewRegistry(), nil, "dev")
+			httpServer = server.NewHTTPServer(queueService, config.ServerConfig{CORSOrigins: "*"}, config.AuthConfig{Enabled: false}, prometheus.NewRegistry(), nil, "dev")
 		})
 
 		Context("when a topic config with max_depth=1 is set and one message is already enqueued", func() {
@@ -1457,7 +1457,7 @@ var _ = Describe("HTTP Server", func() {
 			userToken, err = users.IssueToken([]byte(testJWTSecret), nonAdmin.ID, nonAdmin.Username, nonAdmin.IsAdmin)
 			Expect(err).NotTo(HaveOccurred())
 
-			httpServer = server.NewHTTPServer(queueService, config.AuthConfig{
+			httpServer = server.NewHTTPServer(queueService, config.ServerConfig{CORSOrigins: "*"}, config.AuthConfig{
 				Enabled:   true,
 				JWTSecret: testJWTSecret,
 			}, prometheus.NewRegistry(), userStore, "dev")
@@ -1553,7 +1553,7 @@ var _ = Describe("HTTP Server", func() {
 			userToken, err = users.IssueToken([]byte(testJWTSecret), nonAdmin.ID, nonAdmin.Username, nonAdmin.IsAdmin)
 			Expect(err).NotTo(HaveOccurred())
 
-			httpServer = server.NewHTTPServer(queueService, config.AuthConfig{
+			httpServer = server.NewHTTPServer(queueService, config.ServerConfig{CORSOrigins: "*"}, config.AuthConfig{
 				Enabled:   true,
 				JWTSecret: testJWTSecret,
 			}, prometheus.NewRegistry(), userStore, "dev")
@@ -1610,7 +1610,7 @@ var _ = Describe("HTTP Server", func() {
 			userToken, err = users.IssueToken([]byte(testJWTSecret), nonAdmin.ID, nonAdmin.Username, nonAdmin.IsAdmin)
 			Expect(err).NotTo(HaveOccurred())
 
-			httpServer = server.NewHTTPServer(queueService, config.AuthConfig{
+			httpServer = server.NewHTTPServer(queueService, config.ServerConfig{CORSOrigins: "*"}, config.AuthConfig{
 				Enabled:   true,
 				JWTSecret: testJWTSecret,
 			}, prometheus.NewRegistry(), userStore, "dev")
@@ -1653,7 +1653,7 @@ var _ = Describe("HTTP Server", func() {
 		var httpServer *server.HTTPServer
 
 		BeforeEach(func() {
-			httpServer = server.NewHTTPServer(queueService, config.AuthConfig{Enabled: false}, prometheus.NewRegistry(), nil, "dev")
+			httpServer = server.NewHTTPServer(queueService, config.ServerConfig{CORSOrigins: "*"}, config.AuthConfig{Enabled: false}, prometheus.NewRegistry(), nil, "dev")
 		})
 
 		Context("with no messages", func() {
@@ -1730,7 +1730,7 @@ var _ = Describe("HTTP Server", func() {
 
 		Context("when auth is enabled and no Authorization header is sent", func() {
 			It("should return 401", func() {
-				authServer := server.NewHTTPServer(queueService, config.AuthConfig{
+				authServer := server.NewHTTPServer(queueService, config.ServerConfig{CORSOrigins: "*"}, config.AuthConfig{
 					Enabled:   true,
 					JWTSecret: testJWTSecret,
 				}, prometheus.NewRegistry(), userStore, "dev")

--- a/internal/server/http_test.go
+++ b/internal/server/http_test.go
@@ -521,6 +521,38 @@ var _ = Describe("HTTP Server", func() {
 				Expect(resp.StatusCode).To(Equal(403))
 			})
 		})
+
+		Context("when auth is enabled and no Authorization header is sent", func() {
+			It("should return 401 on requireGrant-protected routes", func() {
+				// GET /api/messages — protected by requireGrant("read")
+				req := httptest.NewRequest("GET", "/api/messages?topic=orders", nil)
+				resp, err := httpServer.App.Test(req)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp.StatusCode).To(Equal(401))
+
+				// POST /api/messages — protected by requireGrant("write")
+				req = httptest.NewRequest("POST", "/api/messages",
+					strings.NewReader(`{"topic":"orders","payload":"hi"}`))
+				req.Header.Set("Content-Type", "application/json")
+				resp, err = httpServer.App.Test(req)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp.StatusCode).To(Equal(401))
+			})
+
+			It("should return 401 on requireAdmin-protected routes", func() {
+				// GET /api/stats — protected by requireAdmin
+				req := httptest.NewRequest("GET", "/api/stats", nil)
+				resp, err := httpServer.App.Test(req)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp.StatusCode).To(Equal(401))
+
+				// GET /api/users — protected by requireAdmin
+				req = httptest.NewRequest("GET", "/api/users", nil)
+				resp, err = httpServer.App.Test(req)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp.StatusCode).To(Equal(401))
+			})
+		})
 	})
 
 	// ---------------------------------------------------------------------------
@@ -1741,6 +1773,107 @@ var _ = Describe("HTTP Server", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(resp.StatusCode).To(Equal(401))
 				Expect(decodeErrorBody(resp.Body)).To(Equal("missing authorization header"))
+			})
+		})
+	})
+
+	// ---------------------------------------------------------------------------
+	// POST /api/users
+	// ---------------------------------------------------------------------------
+
+	Describe("POST /api/users", func() {
+		var httpServer *server.HTTPServer
+		var adminToken string
+
+		BeforeEach(func() {
+			httpServer = server.NewHTTPServer(queueService, config.ServerConfig{CORSOrigins: "*"}, config.AuthConfig{
+				Enabled:   true,
+				JWTSecret: testJWTSecret,
+			}, prometheus.NewRegistry(), userStore, "dev")
+
+			admin, err := userStore.Create(httpTestCtx, "post-users-admin", "strongpassword123", true)
+			Expect(err).NotTo(HaveOccurred())
+			adminToken, err = users.IssueToken([]byte(testJWTSecret), admin.ID, admin.Username, admin.IsAdmin)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		Context("when the password is shorter than 12 characters", func() {
+			It("should return 400 with a descriptive error", func() {
+				body := `{"username":"newuser","password":"short"}`
+				req := httptest.NewRequest("POST", "/api/users", strings.NewReader(body))
+				req.Header.Set("Content-Type", "application/json")
+				req.Header.Set("Authorization", "Bearer "+adminToken)
+				resp, err := httpServer.App.Test(req)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp.StatusCode).To(Equal(400))
+				Expect(decodeErrorBody(resp.Body)).To(Equal("password must be at least 12 characters"))
+			})
+		})
+
+		Context("when the password meets the minimum length", func() {
+			It("should return 201 and create the user", func() {
+				body := `{"username":"newuser","password":"strongpassword123"}`
+				req := httptest.NewRequest("POST", "/api/users", strings.NewReader(body))
+				req.Header.Set("Content-Type", "application/json")
+				req.Header.Set("Authorization", "Bearer "+adminToken)
+				resp, err := httpServer.App.Test(req)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp.StatusCode).To(Equal(201))
+			})
+		})
+	})
+
+	// ---------------------------------------------------------------------------
+	// PUT /api/users/:id
+	// ---------------------------------------------------------------------------
+
+	Describe("PUT /api/users/:id", func() {
+		var httpServer *server.HTTPServer
+		var adminToken string
+		var targetUserID string
+
+		BeforeEach(func() {
+			httpServer = server.NewHTTPServer(queueService, config.ServerConfig{CORSOrigins: "*"}, config.AuthConfig{
+				Enabled:   true,
+				JWTSecret: testJWTSecret,
+			}, prometheus.NewRegistry(), userStore, "dev")
+
+			admin, err := userStore.Create(httpTestCtx, "put-users-admin", "strongpassword123", true)
+			Expect(err).NotTo(HaveOccurred())
+			adminToken, err = users.IssueToken([]byte(testJWTSecret), admin.ID, admin.Username, admin.IsAdmin)
+			Expect(err).NotTo(HaveOccurred())
+
+			target, err := userStore.Create(httpTestCtx, "put-users-target", "strongpassword123", false)
+			Expect(err).NotTo(HaveOccurred())
+			targetUserID = target.ID
+		})
+
+		Context("when the new password is shorter than 12 characters", func() {
+			It("should return 400 with a descriptive error", func() {
+				body := `{"password":"short"}`
+				req := httptest.NewRequest("PUT", "/api/users/"+targetUserID, strings.NewReader(body))
+				req.Header.Set("Content-Type", "application/json")
+				req.Header.Set("Authorization", "Bearer "+adminToken)
+				resp, err := httpServer.App.Test(req)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp.StatusCode).To(Equal(400))
+				Expect(decodeErrorBody(resp.Body)).To(Equal("password must be at least 12 characters"))
+			})
+		})
+
+		Context("when the new password meets the minimum length", func() {
+			It("should return 200 and update the user", func() {
+				body := `{"password":"newstrongpassword123"}`
+				req := httptest.NewRequest("PUT", "/api/users/"+targetUserID, strings.NewReader(body))
+				req.Header.Set("Content-Type", "application/json")
+				req.Header.Set("Authorization", "Bearer "+adminToken)
+				resp, err := httpServer.App.Test(req)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp.StatusCode).To(Equal(200))
 			})
 		})
 	})

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -10,6 +10,9 @@ import (
 func (s *HTTPServer) requireAdmin() fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		claims := internalAuth.ClaimsFromCtx(c)
+		if s.authConfig.Enabled && claims == nil {
+			return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "authentication required"})
+		}
 		if claims == nil {
 			return c.Next()
 		}
@@ -23,6 +26,9 @@ func (s *HTTPServer) requireAdmin() fiber.Handler {
 func (s *HTTPServer) requireGrant(action string, topicFn func(*fiber.Ctx) string) fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		claims := internalAuth.ClaimsFromCtx(c)
+		if s.authConfig.Enabled && claims == nil {
+			return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "authentication required"})
+		}
 		if claims == nil {
 			return c.Next()
 		}
@@ -44,6 +50,9 @@ func (s *HTTPServer) requireGrant(action string, topicFn func(*fiber.Ctx) string
 func (s *HTTPServer) requireWriteOnMsgTopic() fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		claims := internalAuth.ClaimsFromCtx(c)
+		if s.authConfig.Enabled && claims == nil {
+			return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "authentication required"})
+		}
 		if claims == nil {
 			return c.Next()
 		}

--- a/internal/users/users.go
+++ b/internal/users/users.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -112,39 +111,32 @@ func (s *Store) Update(ctx context.Context, id string, username *string, plainPa
 	if username == nil && plainPassword == nil && isAdmin == nil {
 		return s.GetByID(ctx, id)
 	}
-	// Build a partial update with only the provided fields.
-	setClauses := []string{"updated_at = now()"}
-	args := []any{}
-	argN := 1
 
-	if username != nil {
-		setClauses = append(setClauses, fmt.Sprintf("username = $%d", argN))
-		args = append(args, *username)
-		argN++
-	}
+	// Hash the password before building the query so all args are known upfront.
+	var passwordHash *string
 	if plainPassword != nil {
 		hash, err := bcrypt.GenerateFromPassword([]byte(*plainPassword), bcrypt.DefaultCost)
 		if err != nil {
 			return nil, fmt.Errorf("hash password: %w", err)
 		}
-		setClauses = append(setClauses, fmt.Sprintf("password_hash = $%d", argN))
-		args = append(args, string(hash))
-		argN++
+		h := string(hash)
+		passwordHash = &h
 	}
-	if isAdmin != nil {
-		setClauses = append(setClauses, fmt.Sprintf("is_admin = $%d", argN))
-		args = append(args, *isAdmin)
-		argN++
-	}
-	args = append(args, id)
 
-	query := fmt.Sprintf(
-		`UPDATE users SET %s WHERE id = $%d
-         RETURNING id, username, is_admin, created_at, updated_at`,
-		joinClauses(setClauses), argN,
-	)
+	// Static query: CASE WHEN avoids any dynamic SQL construction.
+	// Each column is updated only when the corresponding arg is non-NULL;
+	// otherwise the existing value is preserved.
+	const query = `
+		UPDATE users SET
+			username      = CASE WHEN $2::text     IS NOT NULL THEN $2::text     ELSE username      END,
+			password_hash = CASE WHEN $3::text     IS NOT NULL THEN $3::text     ELSE password_hash END,
+			is_admin      = CASE WHEN $4::boolean  IS NOT NULL THEN $4::boolean  ELSE is_admin      END,
+			updated_at    = now()
+		WHERE id = $1
+		RETURNING id, username, is_admin, created_at, updated_at`
+
 	var u User
-	err := s.pool.QueryRow(ctx, query, args...).Scan(
+	err := s.pool.QueryRow(ctx, query, id, username, passwordHash, isAdmin).Scan(
 		&u.ID, &u.Username, &u.IsAdmin, &u.CreatedAt, &u.UpdatedAt,
 	)
 	if errors.Is(err, pgx.ErrNoRows) {
@@ -232,6 +224,3 @@ func isUniqueViolation(err error) bool {
 	return false
 }
 
-func joinClauses(clauses []string) string {
-	return strings.Join(clauses, ", ")
-}


### PR DESCRIPTION
Critical:
- Remove config.yaml from Docker image (no credentials baked in)
- Clarify default credentials in config.yaml with prominent dev-only warning

High:
- Fix requireAdmin/requireGrant to return 401 when auth enabled but claims nil
- Add rate limiter (10 req/60s per IP) on POST /api/auth/login
- Rewrite users.Update SQL using CASE WHEN — remove fmt.Sprintf construction
- Protect /metrics endpoint with jwtAuth middleware
- Bind gRPC port to 127.0.0.1 in docker-compose (no external exposure)

Medium:
- Add minimum JWT secret length check (32 bytes) at startup
- Make CORS origins configurable via ServerConfig.CORSOrigins
- Default DB sslmode to 'require' (was 'disable')
- Add security headers to Nginx (CSP, X-Frame-Options, HSTS, etc.)
- Document gRPC TLS requirement in README

Low:
- Replace err.Error() with 'internal server error' in all 500 responses
- Enforce minimum password length of 12 characters
- Add comment clarifying JWT client-side decode is display-only
- Add comment explaining sessionStorage choice over localStorage