### PR TITLE
feat: sticky header, pinned footer, and improved footer layout

### DIFF
--- a/admin-ui/src/app/admin/admin.ts
+++ b/admin-ui/src/app/admin/admin.ts
@@ -14,7 +14,7 @@ import { FooterComponent } from '../shared/footer.component';
     <div class="min-h-screen bg-gray-50 flex flex-col">
       <app-messages-header [isAuthenticated]="auth.isAuthenticated()" (signOut)="onLogout()" />
 
-      <div class="flex-1 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 space-y-6">
+      <div class="flex-1 w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 space-y-6">
         <div><app-users-section /></div>
         <div><app-maintenance-section /></div>
       </div>

--- a/admin-ui/src/app/admin/admin.ts
+++ b/admin-ui/src/app/admin/admin.ts
@@ -11,10 +11,10 @@ import { FooterComponent } from '../shared/footer.component';
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [MessagesHeader, UsersSection, MaintenanceSection, FooterComponent],
   template: `
-    <div class="min-h-screen bg-gray-50">
+    <div class="min-h-screen bg-gray-50 flex flex-col">
       <app-messages-header [isAuthenticated]="auth.isAuthenticated()" (signOut)="onLogout()" />
 
-      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 space-y-6">
+      <div class="flex-1 max-w-7xl mx-auto w-full px-4 sm:px-6 lg:px-8 py-6 space-y-6">
         <div><app-users-section /></div>
         <div><app-maintenance-section /></div>
       </div>

--- a/admin-ui/src/app/admin/admin.ts
+++ b/admin-ui/src/app/admin/admin.ts
@@ -14,7 +14,7 @@ import { FooterComponent } from '../shared/footer.component';
     <div class="min-h-screen bg-gray-50 flex flex-col">
       <app-messages-header [isAuthenticated]="auth.isAuthenticated()" (signOut)="onLogout()" />
 
-      <div class="flex-1 max-w-7xl mx-auto w-full px-4 sm:px-6 lg:px-8 py-6 space-y-6">
+      <div class="flex-1 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 space-y-6">
         <div><app-users-section /></div>
         <div><app-maintenance-section /></div>
       </div>

--- a/admin-ui/src/app/messages/messages-header.ts
+++ b/admin-ui/src/app/messages/messages-header.ts
@@ -8,7 +8,7 @@ import { inject } from '@angular/core';
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [RouterLink, RouterLinkActive],
   template: `
-    <header class="bg-white shadow-sm">
+    <header class="bg-white shadow-sm sticky top-0 z-10">
       <div
         class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3"
       >

--- a/admin-ui/src/app/messages/messages.ts
+++ b/admin-ui/src/app/messages/messages.ts
@@ -27,7 +27,7 @@ interface EnqueueState {
   imports: [MessagesHeader, MessagesTable, EnqueueSection, QueueStatsChart, TopicsSection, FooterComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <div class="min-h-screen bg-gray-50">
+    <div class="min-h-screen bg-gray-50 flex flex-col">
       <app-messages-header [isAuthenticated]="auth.isAuthenticated()" (signOut)="onLogout()" />
 
       <div class="bg-white border-b border-gray-200">
@@ -50,7 +50,7 @@ interface EnqueueState {
         </div>
       </div>
 
-      <main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <main class="flex-1 max-w-7xl mx-auto w-full px-4 sm:px-6 lg:px-8 py-8">
         @if (activeTab() === 'messages') {
           @if (purgeResult(); as result) {
             <div class="mb-4 flex items-center justify-between p-3 bg-green-50 border border-green-200 text-green-800 rounded text-sm">

--- a/admin-ui/src/app/messages/messages.ts
+++ b/admin-ui/src/app/messages/messages.ts
@@ -50,7 +50,7 @@ interface EnqueueState {
         </div>
       </div>
 
-      <main class="flex-1 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+      <main class="flex-1 w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         @if (activeTab() === 'messages') {
           @if (purgeResult(); as result) {
             <div class="mb-4 flex items-center justify-between p-3 bg-green-50 border border-green-200 text-green-800 rounded text-sm">

--- a/admin-ui/src/app/messages/messages.ts
+++ b/admin-ui/src/app/messages/messages.ts
@@ -50,7 +50,7 @@ interface EnqueueState {
         </div>
       </div>
 
-      <main class="flex-1 max-w-7xl mx-auto w-full px-4 sm:px-6 lg:px-8 py-8">
+      <main class="flex-1 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         @if (activeTab() === 'messages') {
           @if (purgeResult(); as result) {
             <div class="mb-4 flex items-center justify-between p-3 bg-green-50 border border-green-200 text-green-800 rounded text-sm">

--- a/admin-ui/src/app/shared/footer.component.spec.ts
+++ b/admin-ui/src/app/shared/footer.component.spec.ts
@@ -23,8 +23,9 @@ describe('FooterComponent', () => {
     it('should render the loading placeholder', () => {
       setup();
       fixture.detectChanges();
-      const text: string = fixture.nativeElement.textContent.trim();
-      expect(text).toBe('queue-ti ...');
+      const spans = fixture.nativeElement.querySelectorAll('span');
+      expect(spans[0].textContent.trim()).toBe('queue-ti');
+      expect(spans[1].textContent.trim()).toBe('...');
       httpMock.expectOne('/api/version').flush({ version: '1.0.0' });
     });
   });
@@ -35,8 +36,9 @@ describe('FooterComponent', () => {
       fixture.detectChanges();
       httpMock.expectOne('/api/version').flush({ version: '2.5.0' });
       fixture.detectChanges();
-      const text: string = fixture.nativeElement.textContent.trim();
-      expect(text).toBe('queue-ti 2.5.0');
+      const spans = fixture.nativeElement.querySelectorAll('span');
+      expect(spans[0].textContent.trim()).toBe('queue-ti');
+      expect(spans[1].textContent.trim()).toBe('2.5.0');
     });
   });
 
@@ -46,8 +48,9 @@ describe('FooterComponent', () => {
       fixture.detectChanges();
       httpMock.expectOne('/api/version').error(new ProgressEvent('error'));
       fixture.detectChanges();
-      const text: string = fixture.nativeElement.textContent.trim();
-      expect(text).toBe('queue-ti unknown');
+      const spans = fixture.nativeElement.querySelectorAll('span');
+      expect(spans[0].textContent.trim()).toBe('queue-ti');
+      expect(spans[1].textContent.trim()).toBe('unknown');
     });
   });
 

--- a/admin-ui/src/app/shared/footer.component.ts
+++ b/admin-ui/src/app/shared/footer.component.ts
@@ -5,8 +5,11 @@ import { VersionService } from '../services/version.service';
   selector: 'app-footer',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <footer class="py-4 text-center text-xs text-gray-400">
-      queue-ti {{ version() }}
+    <footer class="border-t border-gray-200 py-3 px-4 sm:px-6 lg:px-8">
+      <div class="max-w-7xl mx-auto flex items-center justify-between text-xs text-gray-400">
+        <span>queue-ti</span>
+        <span>{{ version() }}</span>
+      </div>
     </footer>
   `,
 })


### PR DESCRIPTION
## Summary

- Header sticks to the top of the viewport on scroll (`sticky top-0 z-10`)
- Footer is pinned to the bottom of the screen via flex column layout (`min-h-screen flex flex-col` + `flex-1` on the content area) — no `position: fixed` hacks
- Footer redesigned: `border-t` separator, product name left-aligned and version number right-aligned instead of centered

## Test plan

- [x] Scroll a long message list — header stays visible at the top
- [x] On a near-empty page (few messages) — footer sits at the bottom of the viewport, not mid-page
- [x] Footer shows "queue-ti" on the left and the version on the right
- [x] Admin page (`/admin`) has the same sticky header and pinned footer behaviour