### PR TITLE
chore: replace unused toSignal with takeUntilDestroyed for requeue and nack

### DIFF
--- a/admin-ui/src/app/messages/messages.ts
+++ b/admin-ui/src/app/messages/messages.ts
@@ -1,5 +1,5 @@
 import { Component, inject, computed, signal, ChangeDetectionStrategy, OnInit } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
+import { toSignal, takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Router } from '@angular/router';
 import { getErrorMessage } from '../utils/error';
 import { Subject, switchMap, map, catchError, of, startWith, tap } from 'rxjs';
@@ -151,37 +151,27 @@ export class Messages implements OnInit {
   readonly enqueueError = computed(() => this.enqueueState().error);
   readonly enqueueLoading = computed(() => this.enqueueState().loading);
 
-  private readonly requeueState = toSignal(
+  constructor() {
     this.requeueTrigger$.pipe(
       switchMap((id) =>
         this.queue.requeueMessage(id).pipe(
           tap(() => this.loadMessages()),
-          map(() => ({ loading: false, error: '' })),
-          catchError((err) =>
-            of({ loading: false, error: err.error?.error || 'Failed to requeue' }),
-          ),
-          startWith({ loading: true, error: '' }),
+          catchError(() => of(null)),
         ),
       ),
-    ),
-    { initialValue: { loading: false, error: '' } },
-  );
+      takeUntilDestroyed(),
+    ).subscribe();
 
-  private readonly nackState = toSignal(
     this.nackTrigger$.pipe(
       switchMap(({ id, error }) =>
         this.queue.nackMessage(id, error).pipe(
           tap(() => this.loadMessages()),
-          map(() => ({ loading: false, error: '' })),
-          catchError((err) =>
-            of({ loading: false, error: err.error?.error || 'Failed to nack' }),
-          ),
-          startWith({ loading: true, error: '' }),
+          catchError(() => of(null)),
         ),
       ),
-    ),
-    { initialValue: { loading: false, error: '' } },
-  );
+      takeUntilDestroyed(),
+    ).subscribe();
+  }
 
   ngOnInit(): void {
     this.loadMessages();


### PR DESCRIPTION
Closes #6

## Summary

`requeueState` and `nackState` were `toSignal` wrappers whose only purpose was keeping the subscription alive for the `tap(() => loadMessages())` side effect — their state values were never read.

Replaced with constructor-based subscriptions using `takeUntilDestroyed()`, which handles cleanup automatically on destroy. The `startWith`, `map`, and loading/error shape are removed since no consumer ever read them.

## Test plan

- [x] Requeue a message — message list reloads
- [x] Nack a message — message list reloads
- [x] No TS6133 hints in IDE for the affected file