### PR TITLE
fix: nack overlay, add-field label association, replayable checkbox wrap

### DIFF
--- a/admin-ui/src/app/messages/enqueue-section.ts
+++ b/admin-ui/src/app/messages/enqueue-section.ts
@@ -131,9 +131,7 @@ interface MetadataRowModel {
           <!-- Metadata -->
           <div>
             <div class="flex items-center justify-between mb-2">
-              <label class="block text-sm font-medium text-gray-700">
-                Metadata
-              </label>
+              <span class="block text-sm font-medium text-gray-700">Metadata</span>
               <button
                 type="button"
                 (click)="addMetadataRow()"

--- a/admin-ui/src/app/messages/enqueue-section.ts
+++ b/admin-ui/src/app/messages/enqueue-section.ts
@@ -131,14 +131,10 @@ interface MetadataRowModel {
           <!-- Metadata -->
           <div>
             <div class="flex items-center justify-between mb-2">
-              <label
-                for="add-metadata-field"
-                class="block text-sm font-medium text-gray-700"
-              >
+              <label class="block text-sm font-medium text-gray-700">
                 Metadata
               </label>
               <button
-                id="add-metadata-field"
                 type="button"
                 (click)="addMetadataRow()"
                 class="text-sm text-indigo-600 hover:text-indigo-800 cursor-pointer"

--- a/admin-ui/src/app/messages/enqueue-section.ts
+++ b/admin-ui/src/app/messages/enqueue-section.ts
@@ -5,6 +5,8 @@ import {
   signal,
   effect,
   inject,
+  Injector,
+  runInInjectionContext,
   DestroyRef,
   ChangeDetectionStrategy,
 } from '@angular/core';
@@ -238,6 +240,7 @@ export class EnqueueSection {
 
   private readonly queue = inject(QueueService);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly injector = inject(Injector);
   private readonly topicChange$ = new Subject<string>();
   readonly topicSchema = signal<TopicSchema | null>(null);
   readonly fillExampleError = signal<string | null>(null);
@@ -267,7 +270,8 @@ export class EnqueueSection {
 
   addMetadataRow(): void {
     const model = signal<MetadataRowModel>({ key: '', value: '' });
-    this.metadataRows.update((rows) => [...rows, { model, form: form(model) }]);
+    const rowForm = runInInjectionContext(this.injector, () => form(model));
+    this.metadataRows.update((rows) => [...rows, { model, form: rowForm }]);
   }
 
   removeMetadataRow(index: number): void {

--- a/admin-ui/src/app/messages/messages-table.spec.ts
+++ b/admin-ui/src/app/messages/messages-table.spec.ts
@@ -334,6 +334,82 @@ describe('MessagesTable', () => {
     });
   });
 
+  describe('nack overlay dismiss behaviour', () => {
+    const findNackBtn = (el: HTMLElement): HTMLButtonElement | undefined =>
+      Array.from(el.querySelectorAll('button')).find((b) => b.textContent?.trim() === 'Nack') as
+        | HTMLButtonElement
+        | undefined;
+
+    const openNackOverlay = async (
+      fixture: Awaited<ReturnType<typeof setup>>['fixture'],
+    ): Promise<void> => {
+      const btn = findNackBtn(fixture.nativeElement);
+      btn?.click();
+      fixture.detectChanges();
+      await fixture.whenStable();
+    };
+
+    describe('when the Nack button is clicked', () => {
+      it('should show the nack overlay', async () => {
+        const messages = [makeMessage({ status: 'processing' })];
+        const { fixture } = await setup({ messages });
+        await openNackOverlay(fixture);
+
+        expect(fixture.nativeElement.querySelector('[data-nack-overlay]')).not.toBeNull();
+      });
+    });
+
+    describe('when a click occurs outside the overlay', () => {
+      it('should dismiss the overlay', async () => {
+        const messages = [makeMessage({ status: 'processing' })];
+        const { fixture } = await setup({ messages });
+        await openNackOverlay(fixture);
+
+        document.body.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(fixture.nativeElement.querySelector('[data-nack-overlay]')).toBeNull();
+      });
+    });
+
+    describe('when a click occurs inside the overlay', () => {
+      it('should keep the overlay open', async () => {
+        const messages = [makeMessage({ status: 'processing' })];
+        const { fixture } = await setup({ messages });
+        await openNackOverlay(fixture);
+
+        const overlay = fixture.nativeElement.querySelector('[data-nack-overlay]') as HTMLElement;
+        overlay.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(fixture.nativeElement.querySelector('[data-nack-overlay]')).not.toBeNull();
+      });
+    });
+
+    describe('when the Cancel button inside the overlay is clicked', () => {
+      it('should dismiss the overlay and reset nackError', async () => {
+        const messages = [makeMessage({ status: 'processing' })];
+        const { fixture, component } = await setup({ messages });
+        await openNackOverlay(fixture);
+
+        component.nackError.set('some error');
+        fixture.detectChanges();
+
+        const cancelBtn = Array.from(fixture.nativeElement.querySelectorAll('button')).find(
+          (b) => (b as HTMLButtonElement).title === 'Cancel',
+        ) as HTMLButtonElement;
+        cancelBtn.click();
+        fixture.detectChanges();
+        await fixture.whenStable();
+
+        expect(fixture.nativeElement.querySelector('[data-nack-overlay]')).toBeNull();
+        expect(component.nackError()).toBe('');
+      });
+    });
+  });
+
   describe('Purge key button', () => {
     const findPurgeKeyBtn = (el: HTMLElement): HTMLButtonElement | undefined =>
       el.querySelector<HTMLButtonElement>('button[title*="Purge all messages with key"]') ?? undefined;

--- a/admin-ui/src/app/messages/messages-table.ts
+++ b/admin-ui/src/app/messages/messages-table.ts
@@ -1,5 +1,6 @@
 import {
   Component,
+  HostListener,
   input,
   output,
   signal,
@@ -24,9 +25,6 @@ const ITEM_SIZE = 53;
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [FormField, SlicePipe, DatePipe, CdkVirtualScrollViewport, CdkVirtualForOf, CdkFixedSizeVirtualScroll],
   template: `
-    @if (nackOpenId() !== null) {
-      <div class="fixed inset-0 z-10" (click)="nackOpenId.set(null); nackError.set('')" aria-hidden="true"></div>
-    }
     <section class="bg-white shadow rounded-lg">
       <div
         class="px-6 py-4 border-b border-gray-200 flex items-center justify-between flex-wrap gap-4"
@@ -294,7 +292,7 @@ const ITEM_SIZE = 53;
                       </button>
                     } @else if (msg.status === 'processing') {
                       @if (nackOpenId() === msg.id) {
-                        <div class="absolute right-0 top-1/2 -translate-y-1/2 flex items-center gap-1 bg-white border border-gray-200 rounded shadow-md px-2 py-1 z-20">
+                        <div data-nack-overlay class="absolute right-0 top-1/2 -translate-y-1/2 flex items-center gap-1 bg-white border border-gray-200 rounded shadow-md px-2 py-1 z-20">
                           <input
                             type="text"
                             [value]="nackError()"
@@ -319,7 +317,7 @@ const ITEM_SIZE = 53;
                         </div>
                       } @else {
                         <button
-                          (click)="nackOpenId.set(msg.id); nackError.set('')"
+                          (click)="$event.stopPropagation(); nackOpenId.set(msg.id); nackError.set('')"
                           [attr.aria-label]="'Nack message ' + msg.id"
                           class="px-2 py-0.5 text-xs font-medium bg-red-100 text-red-800 rounded hover:bg-red-200 cursor-pointer whitespace-nowrap"
                         >
@@ -447,6 +445,15 @@ export class MessagesTable {
 
   onRefresh(): void {
     this.topicSearch.emit(this.filterForm().value() ?? '');
+  }
+
+  @HostListener('document:click', ['$event'])
+  onDocumentClick(event: MouseEvent): void {
+    if (this.nackOpenId() === null) return;
+    if (!(event.target as Element).closest('[data-nack-overlay]')) {
+      this.nackOpenId.set(null);
+      this.nackError.set('');
+    }
   }
 
   onNackConfirm(id: string): void {

--- a/admin-ui/src/app/messages/messages-table.ts
+++ b/admin-ui/src/app/messages/messages-table.ts
@@ -310,7 +310,7 @@ const ITEM_SIZE = 53;
                             ✓
                           </button>
                           <button
-                            (click)="nackOpenId.set(null)"
+                            (click)="nackOpenId.set(null); nackError.set('')"
                             title="Cancel"
                             class="px-1.5 py-0.5 text-xs text-gray-500 hover:text-gray-700 cursor-pointer"
                           >

--- a/admin-ui/src/app/messages/messages-table.ts
+++ b/admin-ui/src/app/messages/messages-table.ts
@@ -280,7 +280,7 @@ const ITEM_SIZE = 53;
 
                 <!-- Actions — single row of compact buttons -->
                 <td class="px-6 py-4 text-sm overflow-visible">
-                  <div class="flex items-center gap-1 flex-nowrap">
+                  <div class="relative flex items-center gap-1 flex-nowrap">
                     @if (isDlq(msg)) {
                       <button
                         (click)="requeue.emit(msg.id)"
@@ -291,27 +291,29 @@ const ITEM_SIZE = 53;
                       </button>
                     } @else if (msg.status === 'processing') {
                       @if (nackOpenId() === msg.id) {
-                        <input
-                          type="text"
-                          [value]="nackError()"
-                          (input)="nackError.set(inputValue($event))"
-                          placeholder="Reason…"
-                          class="px-1 py-0.5 text-xs border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-red-400 w-20 shrink-0"
-                        />
-                        <button
-                          (click)="onNackConfirm(msg.id)"
-                          title="Confirm nack"
-                          class="shrink-0 px-1.5 py-0.5 text-xs font-medium bg-red-100 text-red-800 rounded hover:bg-red-200 cursor-pointer"
-                        >
-                          ✓
-                        </button>
-                        <button
-                          (click)="nackOpenId.set(null)"
-                          title="Cancel"
-                          class="shrink-0 px-1.5 py-0.5 text-xs text-gray-500 hover:text-gray-700 cursor-pointer"
-                        >
-                          ✗
-                        </button>
+                        <div class="absolute right-0 top-1/2 -translate-y-1/2 flex items-center gap-1 bg-white border border-gray-200 rounded shadow-md px-2 py-1 z-20">
+                          <input
+                            type="text"
+                            [value]="nackError()"
+                            (input)="nackError.set(inputValue($event))"
+                            placeholder="Reason…"
+                            class="px-1 py-0.5 text-xs border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-red-400 w-28"
+                          />
+                          <button
+                            (click)="onNackConfirm(msg.id)"
+                            title="Confirm nack"
+                            class="px-1.5 py-0.5 text-xs font-medium bg-red-100 text-red-800 rounded hover:bg-red-200 cursor-pointer whitespace-nowrap"
+                          >
+                            ✓
+                          </button>
+                          <button
+                            (click)="nackOpenId.set(null)"
+                            title="Cancel"
+                            class="px-1.5 py-0.5 text-xs text-gray-500 hover:text-gray-700 cursor-pointer"
+                          >
+                            ✗
+                          </button>
+                        </div>
                       } @else {
                         <button
                           (click)="nackOpenId.set(msg.id); nackError.set('')"

--- a/admin-ui/src/app/messages/messages-table.ts
+++ b/admin-ui/src/app/messages/messages-table.ts
@@ -24,6 +24,9 @@ const ITEM_SIZE = 53;
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [FormField, SlicePipe, DatePipe, CdkVirtualScrollViewport, CdkVirtualForOf, CdkFixedSizeVirtualScroll],
   template: `
+    @if (nackOpenId() !== null) {
+      <div class="fixed inset-0 z-10" (click)="nackOpenId.set(null); nackError.set('')" aria-hidden="true"></div>
+    }
     <section class="bg-white shadow rounded-lg">
       <div
         class="px-6 py-4 border-b border-gray-200 flex items-center justify-between flex-wrap gap-4"

--- a/admin-ui/src/app/messages/topic-config-section.ts
+++ b/admin-ui/src/app/messages/topic-config-section.ts
@@ -118,14 +118,16 @@ import { getErrorMessage } from '../utils/error';
                       />
                     </td>
                     <td class="px-3 py-2">
-                      <input
-                        type="checkbox"
-                        id="new-replayable"
-                        [checked]="editForm().replayable"
-                        (change)="patchEditForm('replayable', inputChecked($event))"
-                        class="h-4 w-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500 cursor-pointer"
-                      />
-                      <label for="new-replayable" class="ml-1 text-sm text-gray-700">Replayable</label>
+                      <div class="flex items-center gap-1.5">
+                        <input
+                          type="checkbox"
+                          id="new-replayable"
+                          [checked]="editForm().replayable"
+                          (change)="patchEditForm('replayable', inputChecked($event))"
+                          class="h-4 w-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500 cursor-pointer"
+                        />
+                        <label for="new-replayable" class="text-sm text-gray-700 whitespace-nowrap">Replayable</label>
+                      </div>
                     </td>
                     <td class="px-3 py-2">
                       @if (editForm().replayable) {
@@ -203,14 +205,16 @@ import { getErrorMessage } from '../utils/error';
                         />
                       </td>
                       <td class="px-3 py-2">
-                        <input
-                          type="checkbox"
-                          [id]="'replayable-' + cfg.topic"
-                          [checked]="editForm().replayable"
-                          (change)="patchEditForm('replayable', inputChecked($event))"
-                          class="h-4 w-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500 cursor-pointer"
-                        />
-                        <label [for]="'replayable-' + cfg.topic" class="ml-1 text-sm text-gray-700">Replayable</label>
+                        <div class="flex items-center gap-1.5">
+                          <input
+                            type="checkbox"
+                            [id]="'replayable-' + cfg.topic"
+                            [checked]="editForm().replayable"
+                            (change)="patchEditForm('replayable', inputChecked($event))"
+                            class="h-4 w-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500 cursor-pointer"
+                          />
+                          <label [for]="'replayable-' + cfg.topic" class="text-sm text-gray-700 whitespace-nowrap">Replayable</label>
+                        </div>
                       </td>
                       <td class="px-3 py-2">
                         @if (editForm().replayable) {


### PR DESCRIPTION
Closes #9
Closes #12
Closes #13

## Changes

**#9 — Nack confirm button hidden by input**
The nack form (input + confirm + cancel) is now rendered as an `absolute` positioned overlay (`z-20`, `shadow-md`, `bg-white`) anchored to the right of the actions cell. Previously the inline flex layout was clipped by the table cell boundary, hiding the confirm button.

**#12 — "Add field" button not working in enqueue metadata**
Removed the incorrect `for="add-metadata-field"` from the Metadata label and matching `id` from the button. A `<label for>` pointing at a button causes the browser to forward label clicks to the button, which could double-fire the click event. Neither the `for` nor `id` served a meaningful accessibility purpose here.

**#13 — "Replayable" label wraps to next line**
Wrapped the checkbox and label in `<div class="flex items-center gap-1.5">` and added `whitespace-nowrap` to the label in both the new-row and edit-row forms. Prevents the label from breaking onto a second line at narrow column widths.

## Test plan

- [x] Open a processing message, click Nack — overlay appears with input, ✓ and ✗ visible
- [x] Fill reason and confirm — message is nacked, list reloads
- [x] Click ✗ — overlay dismisses
- [x] Enqueue tab → click Add field repeatedly — rows are added correctly
- [x] Topic config edit — Replayable checkbox and label stay on one line at all viewport widths