### PR TITLE
ci: restrict push trigger to main to prevent duplicate runs on PR branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ["**"]
+    branches: [main]
   pull_request:
     branches: [main]
 


### PR DESCRIPTION
Closes #10

## Change

```diff
 on:
   push:
-    branches: ["**"]
+    branches: [main]
   pull_request:
     branches: [main]
```

## Effect

- PR branch pushes now trigger **one** run via the `pull_request` event only
- `main` continues to be tested after every merge via the `push` event
- No loss of coverage — the `pull_request` event runs against the merge commit, which is the correct ref for PR status checks