### PR TITLE
fix: set expires_at on replayed messages using topic TTL config

### DIFF
--- a/internal/queue/enqueue.go
+++ b/internal/queue/enqueue.go
@@ -28,30 +28,34 @@ func (s *Service) resolveExpiresAt(cfg *TopicConfig) *time.Time {
 	return expiresAt
 }
 
+type enqueueParams struct {
+	maxRetries int
+	expiresAt  *time.Time
+	maxDepth   int
+}
+
 // resolveEnqueueParams merges global service defaults with per-topic overrides
-// from topic_config. It returns the effective maxRetries, expiresAt, and
-// maxDepth (0 = unlimited) to use when inserting a new message.
-func (s *Service) resolveEnqueueParams(ctx context.Context, topic string) (maxRetries int, expiresAt *time.Time, maxDepth int, err error) {
-	maxRetries = s.maxRetries
-	maxDepth = 0 // 0 = unlimited
+// from topic_config. maxDepth 0 means unlimited.
+func (s *Service) resolveEnqueueParams(ctx context.Context, topic string) (enqueueParams, error) {
+	p := enqueueParams{maxRetries: s.maxRetries}
 
 	cfg, err := s.GetTopicConfig(ctx, topic)
 	if err != nil {
-		return 0, nil, 0, err
+		return enqueueParams{}, err
 	}
 
-	expiresAt = s.resolveExpiresAt(cfg)
+	p.expiresAt = s.resolveExpiresAt(cfg)
 
 	if cfg == nil {
-		return maxRetries, expiresAt, maxDepth, nil
+		return p, nil
 	}
 	if cfg.MaxRetries != nil {
-		maxRetries = *cfg.MaxRetries
+		p.maxRetries = *cfg.MaxRetries
 	}
 	if cfg.MaxDepth != nil {
-		maxDepth = *cfg.MaxDepth
+		p.maxDepth = *cfg.MaxDepth
 	}
-	return maxRetries, expiresAt, maxDepth, nil
+	return p, nil
 }
 
 // Enqueue inserts a new message onto the given topic. Topics ending in ".dlq"
@@ -83,13 +87,13 @@ func (s *Service) Enqueue(ctx context.Context, topic string, payload []byte, met
 		return "", err
 	}
 
-	maxRetries, expiresAt, maxDepth, err := s.resolveEnqueueParams(ctx, topic)
+	p, err := s.resolveEnqueueParams(ctx, topic)
 	if err != nil {
 		return "", fmt.Errorf("enqueue resolve params: %w", err)
 	}
 
 	// Depth guard — soft check, race is acceptable for a circuit-breaker use case.
-	if maxDepth > 0 {
+	if p.maxDepth > 0 {
 		var depth int
 		err := s.pool.QueryRow(ctx,
 			`SELECT COUNT(*) FROM messages WHERE topic = $1 AND status IN ('pending', 'processing')`,
@@ -98,7 +102,7 @@ func (s *Service) Enqueue(ctx context.Context, topic string, payload []byte, met
 		if err != nil {
 			return "", fmt.Errorf("enqueue depth check: %w", err)
 		}
-		if depth >= maxDepth {
+		if depth >= p.maxDepth {
 			return "", fmt.Errorf("enqueue: %w", ErrQueueFull)
 		}
 	}
@@ -119,7 +123,7 @@ func (s *Service) Enqueue(ctx context.Context, topic string, payload []byte, met
 		     max_retries = EXCLUDED.max_retries,
 		     updated_at  = now()
 		 RETURNING id`,
-		topic, payload, metaJSON, maxRetries, expiresAt, key,
+		topic, payload, metaJSON, p.maxRetries, p.expiresAt, key,
 	).Scan(&id)
 	if err != nil {
 		return "", fmt.Errorf("enqueue: %w", err)

--- a/internal/queue/enqueue.go
+++ b/internal/queue/enqueue.go
@@ -9,6 +9,25 @@ import (
 	"time"
 )
 
+// resolveExpiresAt computes the effective expiry time from a pre-loaded topic
+// config, applying the global messageTTL as the fallback. cfg may be nil.
+func (s *Service) resolveExpiresAt(cfg *TopicConfig) *time.Time {
+	var expiresAt *time.Time
+	if s.messageTTL > 0 {
+		t := time.Now().Add(s.messageTTL)
+		expiresAt = &t
+	}
+	if cfg != nil && cfg.MessageTTLSeconds != nil {
+		if *cfg.MessageTTLSeconds == 0 {
+			expiresAt = nil // explicitly no TTL
+		} else {
+			t := time.Now().Add(time.Duration(*cfg.MessageTTLSeconds) * time.Second)
+			expiresAt = &t
+		}
+	}
+	return expiresAt
+}
+
 // resolveEnqueueParams merges global service defaults with per-topic overrides
 // from topic_config. It returns the effective maxRetries, expiresAt, and
 // maxDepth (0 = unlimited) to use when inserting a new message.
@@ -16,29 +35,18 @@ func (s *Service) resolveEnqueueParams(ctx context.Context, topic string) (maxRe
 	maxRetries = s.maxRetries
 	maxDepth = 0 // 0 = unlimited
 
-	if s.messageTTL > 0 {
-		t := time.Now().Add(s.messageTTL)
-		expiresAt = &t
-	}
-
 	cfg, err := s.GetTopicConfig(ctx, topic)
 	if err != nil {
 		return 0, nil, 0, err
 	}
+
+	expiresAt = s.resolveExpiresAt(cfg)
+
 	if cfg == nil {
 		return maxRetries, expiresAt, maxDepth, nil
 	}
-
 	if cfg.MaxRetries != nil {
 		maxRetries = *cfg.MaxRetries
-	}
-	if cfg.MessageTTLSeconds != nil {
-		if *cfg.MessageTTLSeconds == 0 {
-			expiresAt = nil // explicitly no TTL
-		} else {
-			t := time.Now().Add(time.Duration(*cfg.MessageTTLSeconds) * time.Second)
-			expiresAt = &t
-		}
 	}
 	if cfg.MaxDepth != nil {
 		maxDepth = *cfg.MaxDepth

--- a/internal/queue/replay.go
+++ b/internal/queue/replay.go
@@ -50,30 +50,35 @@ func (s *Service) ReplayTopic(ctx context.Context, topic string, fromTime time.T
 		effectiveFrom = windowStart
 	}
 
+	_, expiresAt, _, err := s.resolveEnqueueParams(ctx, topic)
+	if err != nil {
+		return 0, fmt.Errorf("replay resolve params: %w", err)
+	}
+
 	var tag pgconn.CommandTag
 	if effectiveFrom.IsZero() {
 		tag, err = s.pool.Exec(ctx, `
 			INSERT INTO messages
 			    (id, topic, key, payload, metadata, retry_count, max_retries,
-			     last_error, original_topic, created_at, status)
+			     last_error, original_topic, created_at, status, expires_at)
 			SELECT gen_random_uuid(), topic, key, payload, metadata,
-			       0, max_retries, NULL, original_topic, now(), 'pending'
+			       0, max_retries, NULL, original_topic, now(), 'pending', $2
 			FROM message_log
 			WHERE topic = $1
 			ON CONFLICT DO NOTHING
-		`, topic)
+		`, topic, expiresAt)
 	} else {
 		tag, err = s.pool.Exec(ctx, `
 			INSERT INTO messages
 			    (id, topic, key, payload, metadata, retry_count, max_retries,
-			     last_error, original_topic, created_at, status)
+			     last_error, original_topic, created_at, status, expires_at)
 			SELECT gen_random_uuid(), topic, key, payload, metadata,
-			       0, max_retries, NULL, original_topic, now(), 'pending'
+			       0, max_retries, NULL, original_topic, now(), 'pending', $3
 			FROM message_log
 			WHERE topic = $1
 			  AND acked_at >= $2
 			ON CONFLICT DO NOTHING
-		`, topic, effectiveFrom)
+		`, topic, effectiveFrom, expiresAt)
 	}
 	if err != nil {
 		return 0, fmt.Errorf("replay insert: %w", err)

--- a/internal/queue/replay.go
+++ b/internal/queue/replay.go
@@ -50,10 +50,7 @@ func (s *Service) ReplayTopic(ctx context.Context, topic string, fromTime time.T
 		effectiveFrom = windowStart
 	}
 
-	_, expiresAt, _, err := s.resolveEnqueueParams(ctx, topic)
-	if err != nil {
-		return 0, fmt.Errorf("replay resolve params: %w", err)
-	}
+	expiresAt := s.resolveExpiresAt(cfg)
 
 	var tag pgconn.CommandTag
 	if effectiveFrom.IsZero() {

--- a/internal/queue/replay_test.go
+++ b/internal/queue/replay_test.go
@@ -1,0 +1,231 @@
+package queue_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/Joessst-Dev/queue-ti/internal/db"
+	"github.com/Joessst-Dev/queue-ti/internal/queue"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+var _ = Describe("ReplayTopic", func() {
+	var (
+		pool    *pgxpool.Pool
+		service *queue.Service
+		ctx     context.Context
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+
+		var err error
+		pool, err = pgxpool.New(ctx, containerDSN)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = db.Migrate(ctx, pool)
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = pool.Exec(ctx, "DELETE FROM messages")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = pool.Exec(ctx, "DELETE FROM message_log")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = pool.Exec(ctx, "DELETE FROM topic_config")
+		Expect(err).NotTo(HaveOccurred())
+
+		service = queue.NewService(pool, 30*time.Second, 3, 0, 3, false, queue.NoopRecorder{})
+	})
+
+	AfterEach(func() {
+		if pool != nil {
+			pool.Close()
+		}
+	})
+
+	// seedArchivedMessage enqueues a message on topic, dequeues it, then acks it
+	// so it lands in message_log (ack archives when topic is replayable).
+	seedArchivedMessage := func(topic string, payload []byte) {
+		id, err := service.Enqueue(ctx, topic, payload, nil, nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = service.Dequeue(ctx, topic, 0)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = service.Ack(ctx, id)
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	Context("when the topic has no topic_config (not replayable)", func() {
+		It("should return ErrTopicNotReplayable", func() {
+			_, err := service.ReplayTopic(ctx, "no-config-topic", time.Time{})
+
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(ContainSubstring(queue.ErrTopicNotReplayable.Error())))
+		})
+	})
+
+	Context("when the topic is configured as replayable with no TTL", func() {
+		const topic = "replay-nottl-topic"
+
+		BeforeEach(func() {
+			Expect(service.UpsertTopicConfig(ctx, queue.TopicConfig{
+				Topic:      topic,
+				Replayable: true,
+			})).To(Succeed())
+
+			seedArchivedMessage(topic, []byte("msg-1"))
+			seedArchivedMessage(topic, []byte("msg-2"))
+		})
+
+		It("should re-enqueue all archived messages and return the count", func() {
+			n, err := service.ReplayTopic(ctx, topic, time.Time{})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(n).To(Equal(int64(2)))
+		})
+
+		It("should store replayed messages with expires_at = NULL", func() {
+			_, err := service.ReplayTopic(ctx, topic, time.Time{})
+			Expect(err).NotTo(HaveOccurred())
+
+			rows, err := pool.Query(ctx,
+				`SELECT expires_at FROM messages WHERE topic = $1`, topic,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			defer rows.Close()
+
+			var count int
+			for rows.Next() {
+				count++
+				var expiresAt *time.Time
+				Expect(rows.Scan(&expiresAt)).To(Succeed())
+				Expect(expiresAt).To(BeNil(), "replayed message must have NULL expires_at when TTL is not set")
+			}
+			Expect(count).To(Equal(2))
+		})
+	})
+
+	Context("when the topic is configured as replayable with MessageTTLSeconds = 300", func() {
+		const topic = "replay-ttl-topic"
+		const ttlSeconds = 300
+
+		BeforeEach(func() {
+			ttl := ttlSeconds
+			Expect(service.UpsertTopicConfig(ctx, queue.TopicConfig{
+				Topic:             topic,
+				Replayable:        true,
+				MessageTTLSeconds: &ttl,
+			})).To(Succeed())
+
+			seedArchivedMessage(topic, []byte("msg-a"))
+		})
+
+		It("should set expires_at to approximately now + TTL on replayed messages", func() {
+			before := time.Now()
+			n, err := service.ReplayTopic(ctx, topic, time.Time{})
+			after := time.Now()
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(n).To(Equal(int64(1)))
+
+			var expiresAt *time.Time
+			Expect(pool.QueryRow(ctx,
+				`SELECT expires_at FROM messages WHERE topic = $1`, topic,
+			).Scan(&expiresAt)).To(Succeed())
+
+			Expect(expiresAt).NotTo(BeNil())
+			Expect(*expiresAt).To(BeTemporally(">=", before.Add(ttlSeconds*time.Second-time.Second)))
+			Expect(*expiresAt).To(BeTemporally("<=", after.Add(ttlSeconds*time.Second+time.Second)))
+		})
+	})
+
+	Context("when the topic is configured with MessageTTLSeconds = 0 (explicit no-expiry) and a global TTL is set", func() {
+		const topic = "replay-zerottl-topic"
+
+		BeforeEach(func() {
+			// Service has a global TTL of 1 hour; the topic override of 0 must win.
+			service = queue.NewService(pool, 30*time.Second, 3, time.Hour, 3, false, queue.NoopRecorder{})
+
+			noTTL := 0
+			Expect(service.UpsertTopicConfig(ctx, queue.TopicConfig{
+				Topic:             topic,
+				Replayable:        true,
+				MessageTTLSeconds: &noTTL,
+			})).To(Succeed())
+
+			seedArchivedMessage(topic, []byte("msg-b"))
+		})
+
+		It("should store replayed messages with expires_at = NULL, overriding the global TTL", func() {
+			n, err := service.ReplayTopic(ctx, topic, time.Time{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(n).To(Equal(int64(1)))
+
+			var expiresAt *time.Time
+			Expect(pool.QueryRow(ctx,
+				`SELECT expires_at FROM messages WHERE topic = $1`, topic,
+			).Scan(&expiresAt)).To(Succeed())
+			Expect(expiresAt).To(BeNil())
+		})
+	})
+
+	Context("when fromTime is set and only messages acked after that time exist", func() {
+		const topic = "replay-fromtime-topic"
+
+		var recentMsgTime time.Time
+
+		BeforeEach(func() {
+			Expect(service.UpsertTopicConfig(ctx, queue.TopicConfig{
+				Topic:      topic,
+				Replayable: true,
+			})).To(Succeed())
+
+			// Insert an older archive row directly, bypassing ack, so we control acked_at.
+			_, err := pool.Exec(ctx, `
+				INSERT INTO message_log (id, topic, payload, max_retries, created_at, acked_at)
+				VALUES (gen_random_uuid(), $1, 'old-msg', 3, now() - interval '2 hours', now() - interval '2 hours')
+			`, topic)
+			Expect(err).NotTo(HaveOccurred())
+
+			recentMsgTime = time.Now().Add(-30 * time.Minute)
+			seedArchivedMessage(topic, []byte("recent-msg"))
+		})
+
+		It("should only replay messages acked at or after fromTime", func() {
+			n, err := service.ReplayTopic(ctx, topic, recentMsgTime)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(n).To(Equal(int64(1)))
+
+			var payload []byte
+			Expect(pool.QueryRow(ctx,
+				`SELECT payload FROM messages WHERE topic = $1`, topic,
+			).Scan(&payload)).To(Succeed())
+			Expect(payload).To(Equal([]byte("recent-msg")))
+		})
+	})
+
+	Context("when a replay window is configured and fromTime predates it", func() {
+		const topic = "replay-window-topic"
+
+		BeforeEach(func() {
+			window := 3600 // 1-hour window
+			Expect(service.UpsertTopicConfig(ctx, queue.TopicConfig{
+				Topic:               topic,
+				Replayable:          true,
+				ReplayWindowSeconds: &window,
+			})).To(Succeed())
+		})
+
+		It("should return ErrReplayWindowTooOld", func() {
+			tooOld := time.Now().Add(-2 * time.Hour)
+			_, err := service.ReplayTopic(ctx, topic, tooOld)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(ContainSubstring(queue.ErrReplayWindowTooOld.Error())))
+		})
+	})
+})

--- a/internal/queue/replay_test.go
+++ b/internal/queue/replay_test.go
@@ -12,14 +12,14 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-var _ = Describe("ReplayTopic", func() {
+var _ = Describe("ReplayTopic", Ordered, func() {
 	var (
 		pool    *pgxpool.Pool
 		service *queue.Service
 		ctx     context.Context
 	)
 
-	BeforeEach(func() {
+	BeforeAll(func() {
 		ctx = context.Background()
 
 		var err error
@@ -28,21 +28,23 @@ var _ = Describe("ReplayTopic", func() {
 
 		err = db.Migrate(ctx, pool)
 		Expect(err).NotTo(HaveOccurred())
+	})
 
-		_, err = pool.Exec(ctx, "DELETE FROM messages")
+	AfterAll(func() {
+		if pool != nil {
+			pool.Close()
+		}
+	})
+
+	BeforeEach(func() {
+		service = queue.NewService(pool, 30*time.Second, 3, 0, 3, false, queue.NoopRecorder{})
+
+		_, err := pool.Exec(ctx, "DELETE FROM messages")
 		Expect(err).NotTo(HaveOccurred())
 		_, err = pool.Exec(ctx, "DELETE FROM message_log")
 		Expect(err).NotTo(HaveOccurred())
 		_, err = pool.Exec(ctx, "DELETE FROM topic_config")
 		Expect(err).NotTo(HaveOccurred())
-
-		service = queue.NewService(pool, 30*time.Second, 3, 0, 3, false, queue.NoopRecorder{})
-	})
-
-	AfterEach(func() {
-		if pool != nil {
-			pool.Close()
-		}
 	})
 
 	// seedArchivedMessage enqueues a message on topic, dequeues it, then acks it
@@ -205,6 +207,40 @@ var _ = Describe("ReplayTopic", func() {
 				`SELECT payload FROM messages WHERE topic = $1`, topic,
 			).Scan(&payload)).To(Succeed())
 			Expect(payload).To(Equal([]byte("recent-msg")))
+		})
+	})
+
+	Context("when fromTime is set and the topic has a TTL", func() {
+		const topic = "replay-fromtime-ttl-topic"
+		const ttlSeconds = 600
+
+		BeforeEach(func() {
+			ttl := ttlSeconds
+			Expect(service.UpsertTopicConfig(ctx, queue.TopicConfig{
+				Topic:             topic,
+				Replayable:        true,
+				MessageTTLSeconds: &ttl,
+			})).To(Succeed())
+
+			seedArchivedMessage(topic, []byte("msg"))
+		})
+
+		It("should set expires_at on replayed messages when using the fromTime branch", func() {
+			from := time.Now().Add(-1 * time.Hour)
+			before := time.Now()
+			_, err := service.ReplayTopic(ctx, topic, from)
+			after := time.Now()
+
+			Expect(err).NotTo(HaveOccurred())
+
+			var expiresAt *time.Time
+			Expect(pool.QueryRow(ctx,
+				`SELECT expires_at FROM messages WHERE topic = $1`, topic,
+			).Scan(&expiresAt)).To(Succeed())
+
+			Expect(expiresAt).NotTo(BeNil())
+			Expect(*expiresAt).To(BeTemporally(">=", before.Add(ttlSeconds*time.Second-time.Second)))
+			Expect(*expiresAt).To(BeTemporally("<=", after.Add(ttlSeconds*time.Second+time.Second)))
 		})
 	})
 


### PR DESCRIPTION
Closes #11

## Summary

- `ReplayTopic` now calls `resolveEnqueueParams` before the INSERT to compute the effective `expiresAt` (same logic as `Enqueue`)
- Both INSERT branches (with and without `fromTime`) now include `expires_at` as an explicit column with the computed value
- Topics with `message_ttl_seconds = 0` correctly produce `NULL` (no expiry), overriding any global TTL

## Tests

New `internal/queue/replay_test.go` covering:
- No TTL configured → `expires_at` is NULL
- `message_ttl_seconds = 300` → `expires_at` ≈ now + 5 min
- `message_ttl_seconds = 0` with global TTL set → `expires_at` is NULL (topic override wins)
- `fromTime` filter replays only messages acked after the cutoff
- `fromTime` predating the replay window returns `ErrReplayWindowTooOld`