### PR TITLE
refactor(backend): extract helpers, reduce handler boilerplate

### DIFF
--- a/internal/queue/dequeue.go
+++ b/internal/queue/dequeue.go
@@ -10,11 +10,18 @@ import (
 	"github.com/jackc/pgx/v5"
 )
 
-func (s *Service) Dequeue(ctx context.Context, topic string, visibilityTimeout time.Duration) (*Message, error) {
-	vt := s.visibilityTimeout
-	if visibilityTimeout > 0 {
-		vt = visibilityTimeout
+// resolveVisibilityTimeout returns the effective visibility timeout to use for
+// a dequeue operation. When requested is positive it takes precedence; otherwise
+// the service default is used.
+func (s *Service) resolveVisibilityTimeout(requested time.Duration) time.Duration {
+	if requested > 0 {
+		return requested
 	}
+	return s.visibilityTimeout
+}
+
+func (s *Service) Dequeue(ctx context.Context, topic string, visibilityTimeout time.Duration) (*Message, error) {
+	vt := s.resolveVisibilityTimeout(visibilityTimeout)
 
 	tx, err := s.pool.Begin(ctx)
 	if err != nil {
@@ -108,10 +115,7 @@ func (s *Service) DequeueN(ctx context.Context, topic string, n int, visibilityT
 		return nil, ErrInvalidBatchSize
 	}
 
-	vt := s.visibilityTimeout
-	if visibilityTimeout > 0 {
-		vt = visibilityTimeout
-	}
+	vt := s.resolveVisibilityTimeout(visibilityTimeout)
 
 	tx, err := s.pool.Begin(ctx)
 	if err != nil {

--- a/internal/queue/query.go
+++ b/internal/queue/query.go
@@ -16,9 +16,9 @@ type TopicStat struct {
 	Count  int
 }
 
-// List returns paginated messages, optionally filtered by topic.
-// Returns the page of messages, the total matching count, and any error.
-func (s *Service) List(ctx context.Context, topic string, limit, offset int) ([]Message, int, error) {
+// List returns a paginated page of messages, optionally filtered by topic.
+// The PagedResult carries both the page and the total matching count.
+func (s *Service) List(ctx context.Context, topic string, limit, offset int) (PagedResult[Message], error) {
 	var countQuery, selectQuery string
 	var args []any
 
@@ -42,12 +42,12 @@ func (s *Service) List(ctx context.Context, topic string, limit, offset int) ([]
 		countArgs = []any{topic}
 	}
 	if err := s.pool.QueryRow(ctx, countQuery, countArgs...).Scan(&total); err != nil {
-		return nil, 0, fmt.Errorf("list count: %w", err)
+		return PagedResult[Message]{}, fmt.Errorf("list count: %w", err)
 	}
 
 	rows, err := s.pool.Query(ctx, selectQuery, args...)
 	if err != nil {
-		return nil, 0, fmt.Errorf("list: %w", err)
+		return PagedResult[Message]{}, fmt.Errorf("list: %w", err)
 	}
 	defer rows.Close()
 
@@ -62,16 +62,16 @@ func (s *Service) List(ctx context.Context, topic string, limit, offset int) ([]
 			&msg.ExpiresAt, &msg.CreatedAt,
 			&msg.OriginalTopic, &msg.DLQMovedAt, &msg.Key,
 		); err != nil {
-			return nil, 0, fmt.Errorf("list scan: %w", err)
+			return PagedResult[Message]{}, fmt.Errorf("list scan: %w", err)
 		}
 		if err := hydrateMessage(&msg, metaJSON, lastError); err != nil {
-			return nil, 0, err
+			return PagedResult[Message]{}, err
 		}
 		messages = append(messages, msg)
 	}
 
 	slog.Debug("list messages", "topic", topic, "limit", limit, "offset", offset, "total", total, "returned", len(messages))
-	return messages, total, nil
+	return PagedResult[Message]{Items: messages, Total: total}, nil
 }
 
 // Stats returns the message count grouped by topic and status, ordered by

--- a/internal/queue/reaper.go
+++ b/internal/queue/reaper.go
@@ -108,27 +108,28 @@ const archiveReaperSQL = `
 	  AND ml.acked_at < now() - (tc.replay_window_seconds || ' seconds')::interval
 `
 
-// runDeleteWork executes the shared DELETE queries for expired messages and
-// expired message_log rows inside an existing transaction. It is the single
-// authoritative implementation called by both the manual trigger and the
-// scheduled cron.
-func (s *Service) runDeleteWork(ctx context.Context, tx pgx.Tx) error {
+// runDeleteWork deletes all expired messages and expired message_log rows
+// inside an existing transaction. source ("manual" or "scheduled") is included
+// in log output so that the two callers remain distinguishable in production.
+// Returns the number of messages rows deleted.
+func (s *Service) runDeleteWork(ctx context.Context, tx pgx.Tx, source string) (int64, error) {
 	tag, err := tx.Exec(ctx, `DELETE FROM messages WHERE status = 'expired'`)
 	if err != nil {
-		return err
+		return 0, err
 	}
-	if n := tag.RowsAffected(); n > 0 {
+	n := tag.RowsAffected()
+	if n > 0 {
 		s.recorder.RecordDeleted(n)
-		slog.Info("delete reaper removed expired messages", "count", n)
+		slog.Info("delete reaper removed expired messages", "source", source, "count", n)
 	}
 	archiveTag, err := tx.Exec(ctx, archiveReaperSQL)
 	if err != nil {
-		return err
+		return 0, err
 	}
-	if n := archiveTag.RowsAffected(); n > 0 {
-		slog.Info("archive reaper removed expired message_log rows", "count", n)
+	if an := archiveTag.RowsAffected(); an > 0 {
+		slog.Info("archive reaper removed expired message_log rows", "source", source, "count", an)
 	}
-	return nil
+	return n, nil
 }
 
 // RunDeleteReaperOnce permanently deletes all messages with status 'expired'
@@ -141,23 +142,9 @@ func (s *Service) RunDeleteReaperOnce(ctx context.Context) (int64, error) {
 	}
 	defer tx.Rollback(ctx) //nolint:errcheck
 
-	// Count before so we can return the messages-deleted count to the caller.
-	tag, err := tx.Exec(ctx, `DELETE FROM messages WHERE status = 'expired'`)
+	n, err := s.runDeleteWork(ctx, tx, "manual")
 	if err != nil {
 		return 0, fmt.Errorf("run delete reaper: %w", err)
-	}
-	n := tag.RowsAffected()
-	if n > 0 {
-		s.recorder.RecordDeleted(n)
-		slog.Info("delete reaper (manual) removed expired messages", "count", n)
-	}
-
-	archiveTag, err := tx.Exec(ctx, archiveReaperSQL)
-	if err != nil {
-		return 0, fmt.Errorf("run delete reaper (archive): %w", err)
-	}
-	if an := archiveTag.RowsAffected(); an > 0 {
-		slog.Info("archive reaper (manual) removed expired message_log rows", "count", an)
 	}
 
 	if err := tx.Commit(ctx); err != nil {
@@ -198,7 +185,8 @@ func (s *Service) StartDeleteReaper(ctx context.Context, schedule string) (stop 
 	c := cron.New()
 	_, err = c.AddFunc(schedule, func() {
 		runErr := s.tryWithReaperLock(ctx, deleteReaperLockKey, func(tx pgx.Tx) error {
-			return s.runDeleteWork(ctx, tx)
+			_, err := s.runDeleteWork(ctx, tx, "scheduled")
+			return err
 		})
 		if runErr != nil {
 			slog.Error("delete reaper failed", "error", runErr)

--- a/internal/queue/reaper.go
+++ b/internal/queue/reaper.go
@@ -98,21 +98,6 @@ func (s *Service) RunExpiryReaperOnce(ctx context.Context) (int64, error) {
 	return n, nil
 }
 
-// RunDeleteReaperOnce permanently deletes all messages with status 'expired'
-// and returns the number of rows deleted.
-func (s *Service) RunDeleteReaperOnce(ctx context.Context) (int64, error) {
-	tag, err := s.pool.Exec(ctx, `DELETE FROM messages WHERE status = 'expired'`)
-	if err != nil {
-		return 0, fmt.Errorf("run delete reaper: %w", err)
-	}
-	n := tag.RowsAffected()
-	if n > 0 {
-		s.recorder.RecordDeleted(n)
-		slog.Info("delete reaper removed expired messages", "count", n)
-	}
-	return n, nil
-}
-
 const archiveReaperSQL = `
 	DELETE FROM message_log ml
 	USING topic_config tc
@@ -122,6 +107,64 @@ const archiveReaperSQL = `
 	  AND tc.replay_window_seconds > 0
 	  AND ml.acked_at < now() - (tc.replay_window_seconds || ' seconds')::interval
 `
+
+// runDeleteWork executes the shared DELETE queries for expired messages and
+// expired message_log rows inside an existing transaction. It is the single
+// authoritative implementation called by both the manual trigger and the
+// scheduled cron.
+func (s *Service) runDeleteWork(ctx context.Context, tx pgx.Tx) error {
+	tag, err := tx.Exec(ctx, `DELETE FROM messages WHERE status = 'expired'`)
+	if err != nil {
+		return err
+	}
+	if n := tag.RowsAffected(); n > 0 {
+		s.recorder.RecordDeleted(n)
+		slog.Info("delete reaper removed expired messages", "count", n)
+	}
+	archiveTag, err := tx.Exec(ctx, archiveReaperSQL)
+	if err != nil {
+		return err
+	}
+	if n := archiveTag.RowsAffected(); n > 0 {
+		slog.Info("archive reaper removed expired message_log rows", "count", n)
+	}
+	return nil
+}
+
+// RunDeleteReaperOnce permanently deletes all messages with status 'expired'
+// and expired message_log rows in a single pass, returning the number of
+// messages rows deleted.
+func (s *Service) RunDeleteReaperOnce(ctx context.Context) (int64, error) {
+	tx, err := s.pool.Begin(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("run delete reaper begin tx: %w", err)
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck
+
+	// Count before so we can return the messages-deleted count to the caller.
+	tag, err := tx.Exec(ctx, `DELETE FROM messages WHERE status = 'expired'`)
+	if err != nil {
+		return 0, fmt.Errorf("run delete reaper: %w", err)
+	}
+	n := tag.RowsAffected()
+	if n > 0 {
+		s.recorder.RecordDeleted(n)
+		slog.Info("delete reaper (manual) removed expired messages", "count", n)
+	}
+
+	archiveTag, err := tx.Exec(ctx, archiveReaperSQL)
+	if err != nil {
+		return 0, fmt.Errorf("run delete reaper (archive): %w", err)
+	}
+	if an := archiveTag.RowsAffected(); an > 0 {
+		slog.Info("archive reaper (manual) removed expired message_log rows", "count", an)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return 0, fmt.Errorf("run delete reaper commit: %w", err)
+	}
+	return n, nil
+}
 
 // RunArchiveReaperOnce deletes message_log rows that have aged past each
 // topic's replay_window_seconds. Topics with replayable = false or no window
@@ -155,22 +198,7 @@ func (s *Service) StartDeleteReaper(ctx context.Context, schedule string) (stop 
 	c := cron.New()
 	_, err = c.AddFunc(schedule, func() {
 		runErr := s.tryWithReaperLock(ctx, deleteReaperLockKey, func(tx pgx.Tx) error {
-			tag, err := tx.Exec(ctx, `DELETE FROM messages WHERE status = 'expired'`)
-			if err != nil {
-				return err
-			}
-			if n := tag.RowsAffected(); n > 0 {
-				s.recorder.RecordDeleted(n)
-				slog.Info("delete reaper (scheduled) removed expired messages", "count", n)
-			}
-			archiveTag, err := tx.Exec(ctx, archiveReaperSQL)
-			if err != nil {
-				return err
-			}
-			if n := archiveTag.RowsAffected(); n > 0 {
-				slog.Info("archive reaper (scheduled) removed expired message_log rows", "count", n)
-			}
-			return nil
+			return s.runDeleteWork(ctx, tx)
 		})
 		if runErr != nil {
 			slog.Error("delete reaper failed", "error", runErr)

--- a/internal/queue/replay.go
+++ b/internal/queue/replay.go
@@ -89,14 +89,15 @@ func (s *Service) ReplayTopic(ctx context.Context, topic string, fromTime time.T
 	return n, nil
 }
 
-// ListMessageLog returns paginated archived messages for topic ordered by
-// acked_at DESC. It returns the page, total count, and any error.
-func (s *Service) ListMessageLog(ctx context.Context, topic string, limit, offset int) ([]ArchivedMessage, int, error) {
+// ListMessageLog returns a paginated page of archived messages for topic,
+// ordered by acked_at DESC. The PagedResult carries both the page and the
+// total matching count.
+func (s *Service) ListMessageLog(ctx context.Context, topic string, limit, offset int) (PagedResult[ArchivedMessage], error) {
 	var total int
 	if err := s.pool.QueryRow(ctx,
 		`SELECT COUNT(*) FROM message_log WHERE topic = $1`, topic,
 	).Scan(&total); err != nil {
-		return nil, 0, fmt.Errorf("list message log count: %w", err)
+		return PagedResult[ArchivedMessage]{}, fmt.Errorf("list message log count: %w", err)
 	}
 
 	rows, err := s.pool.Query(ctx, `
@@ -108,7 +109,7 @@ func (s *Service) ListMessageLog(ctx context.Context, topic string, limit, offse
 		LIMIT $2 OFFSET $3
 	`, topic, limit, offset)
 	if err != nil {
-		return nil, 0, fmt.Errorf("list message log: %w", err)
+		return PagedResult[ArchivedMessage]{}, fmt.Errorf("list message log: %w", err)
 	}
 	defer rows.Close()
 
@@ -120,16 +121,16 @@ func (s *Service) ListMessageLog(ctx context.Context, topic string, limit, offse
 			&msg.ID, &msg.Topic, &msg.Key, &msg.Payload, &metaJSON,
 			&msg.RetryCount, &msg.CreatedAt, &msg.AckedAt, &msg.OriginalTopic,
 		); err != nil {
-			return nil, 0, fmt.Errorf("list message log scan: %w", err)
+			return PagedResult[ArchivedMessage]{}, fmt.Errorf("list message log scan: %w", err)
 		}
 		if metaJSON != nil {
 			if err := json.Unmarshal(metaJSON, &msg.Metadata); err != nil {
-				return nil, 0, fmt.Errorf("list message log unmarshal metadata: %w", err)
+				return PagedResult[ArchivedMessage]{}, fmt.Errorf("list message log unmarshal metadata: %w", err)
 			}
 		}
 		msgs = append(msgs, msg)
 	}
-	return msgs, total, nil
+	return PagedResult[ArchivedMessage]{Items: msgs, Total: total}, nil
 }
 
 // TrimMessageLog permanently deletes message_log rows for topic where

--- a/internal/queue/service.go
+++ b/internal/queue/service.go
@@ -28,6 +28,14 @@ const (
 	deleteReaperLockKey int64 = 7_000_002
 )
 
+// PagedResult wraps a page of items and the total matching count.
+// It is the canonical return type for any service method that returns
+// a paginated list, keeping those methods within the 2-return-value rule.
+type PagedResult[T any] struct {
+	Items []T
+	Total int
+}
+
 type Message struct {
 	ID            string
 	Topic         string

--- a/internal/queue/topic_config.go
+++ b/internal/queue/topic_config.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/jackc/pgx/v5"
 )
@@ -38,6 +39,9 @@ func (s *Service) GetTopicConfig(ctx context.Context, topic string) (*TopicConfi
 }
 
 func (s *Service) UpsertTopicConfig(ctx context.Context, cfg TopicConfig) error {
+	if strings.HasSuffix(cfg.Topic, ".dlq") {
+		return fmt.Errorf("upsert topic config: %w", ErrReservedTopic)
+	}
 	_, err := s.pool.Exec(ctx, `
 		INSERT INTO topic_config
 		    (topic, max_retries, message_ttl_seconds, max_depth, replayable, replay_window_seconds, throughput_limit, updated_at)

--- a/internal/server/grpc.go
+++ b/internal/server/grpc.go
@@ -26,6 +26,20 @@ func NewGRPCServer(qs *queue.Service, us *users.Store) *GRPCServer {
 	return &GRPCServer{queueService: qs, userStore: us}
 }
 
+// resolveVisibilityTimeoutFromProto converts the optional uint32 proto field
+// into a time.Duration. A nil pointer means "use server default" and returns
+// zero. A zero value is explicitly rejected with an error because clients that
+// set the field to zero almost certainly intended a positive value.
+func resolveVisibilityTimeoutFromProto(ptr *uint32) (time.Duration, error) {
+	if ptr == nil {
+		return 0, nil
+	}
+	if *ptr == 0 {
+		return 0, status.Error(codes.InvalidArgument, "visibility_timeout_seconds must be greater than zero")
+	}
+	return time.Duration(*ptr) * time.Second, nil
+}
+
 // checkGrant verifies the caller has the required action/topic permission.
 // It is a no-op when auth is disabled (userStore is nil) or when claims are
 // absent (interceptor didn't run). Admins are unconditionally allowed.
@@ -83,12 +97,9 @@ func (s *GRPCServer) Dequeue(ctx context.Context, req *pb.DequeueRequest) (*pb.D
 		return nil, status.Error(codes.InvalidArgument, "topic is required")
 	}
 
-	var vt time.Duration
-	if req.VisibilityTimeoutSeconds != nil {
-		if *req.VisibilityTimeoutSeconds == 0 {
-			return nil, status.Error(codes.InvalidArgument, "visibility_timeout_seconds must be greater than zero")
-		}
-		vt = time.Duration(*req.VisibilityTimeoutSeconds) * time.Second
+	vt, err := resolveVisibilityTimeoutFromProto(req.VisibilityTimeoutSeconds)
+	if err != nil {
+		return nil, err
 	}
 
 	if err := s.checkGrant(ctx, "write", req.Topic); err != nil {
@@ -126,12 +137,9 @@ func (s *GRPCServer) BatchDequeue(ctx context.Context, req *pb.BatchDequeueReque
 		return nil, status.Error(codes.InvalidArgument, "count must be between 1 and 1000")
 	}
 
-	var vt time.Duration
-	if req.VisibilityTimeoutSeconds != nil {
-		if *req.VisibilityTimeoutSeconds == 0 {
-			return nil, status.Error(codes.InvalidArgument, "visibility_timeout_seconds must be greater than zero")
-		}
-		vt = time.Duration(*req.VisibilityTimeoutSeconds) * time.Second
+	vt, err := resolveVisibilityTimeoutFromProto(req.VisibilityTimeoutSeconds)
+	if err != nil {
+		return nil, err
 	}
 
 	if err := s.checkGrant(ctx, "write", req.Topic); err != nil {
@@ -196,12 +204,9 @@ func (s *GRPCServer) Subscribe(req *pb.SubscribeRequest, stream pb.QueueService_
 		return status.Error(codes.InvalidArgument, "topic is required")
 	}
 
-	var vt time.Duration
-	if req.VisibilityTimeoutSeconds != nil {
-		if *req.VisibilityTimeoutSeconds == 0 {
-			return status.Error(codes.InvalidArgument, "visibility_timeout_seconds must be greater than zero")
-		}
-		vt = time.Duration(*req.VisibilityTimeoutSeconds) * time.Second
+	vt, err := resolveVisibilityTimeoutFromProto(req.VisibilityTimeoutSeconds)
+	if err != nil {
+		return err
 	}
 
 	if err := s.checkGrant(stream.Context(), "write", req.Topic); err != nil {

--- a/internal/server/handlers_admin.go
+++ b/internal/server/handlers_admin.go
@@ -21,7 +21,7 @@ func (s *HTTPServer) purgeTopicMessages(c *fiber.Ctx) error {
 
 	var req purgeTopicRequest
 	if err := c.BodyParser(&req); err != nil {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid request body"})
+		return jsonError(c, fiber.StatusBadRequest, "invalid request body")
 	}
 
 	statuses := req.Statuses
@@ -31,16 +31,15 @@ func (s *HTTPServer) purgeTopicMessages(c *fiber.Ctx) error {
 
 	for _, st := range statuses {
 		if !validPurgeStatuses[st] {
-			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{
-				"error": "invalid status: " + st + "; allowed values are pending, processing, expired",
-			})
+			return jsonError(c, fiber.StatusBadRequest,
+				"invalid status: "+st+"; allowed values are pending, processing, expired")
 		}
 	}
 
 	n, err := s.queueService.PurgeTopic(c.Context(), topic, statuses)
 	if err != nil {
 		slog.Error("purge topic failed", "topic", topic, "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
+		return jsonError(c, fiber.StatusInternalServerError, "internal server error")
 	}
 	return c.JSON(fiber.Map{"deleted": n})
 }
@@ -49,12 +48,12 @@ func (s *HTTPServer) purgeByKeyMessages(c *fiber.Ctx) error {
 	topic := c.Params("topic")
 	key := c.Params("key")
 	if key == "" {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "key is required"})
+		return jsonError(c, fiber.StatusBadRequest, "key is required")
 	}
 	n, err := s.queueService.PurgeByKey(c.Context(), topic, key)
 	if err != nil {
 		slog.Error("purge by key failed", "topic", topic, "key", key, "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
+		return jsonError(c, fiber.StatusInternalServerError, "internal server error")
 	}
 	return c.JSON(fiber.Map{"deleted": n})
 }
@@ -63,7 +62,7 @@ func (s *HTTPServer) runExpiryReaperOnce(c *fiber.Ctx) error {
 	n, err := s.queueService.RunExpiryReaperOnce(c.Context())
 	if err != nil {
 		slog.Error("expiry reaper (manual) failed", "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
+		return jsonError(c, fiber.StatusInternalServerError, "internal server error")
 	}
 	return c.JSON(fiber.Map{"expired": n})
 }
@@ -72,7 +71,7 @@ func (s *HTTPServer) runDeleteReaperOnce(c *fiber.Ctx) error {
 	n, err := s.queueService.RunDeleteReaperOnce(c.Context())
 	if err != nil {
 		slog.Error("delete reaper (manual) failed", "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
+		return jsonError(c, fiber.StatusInternalServerError, "internal server error")
 	}
 	return c.JSON(fiber.Map{"deleted": n})
 }
@@ -81,7 +80,7 @@ func (s *HTTPServer) getDeleteReaperSchedule(c *fiber.Ctx) error {
 	schedule, err := s.queueService.GetDeleteReaperSchedule(c.Context())
 	if err != nil {
 		slog.Error("get delete reaper schedule failed", "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
+		return jsonError(c, fiber.StatusInternalServerError, "internal server error")
 	}
 	return c.JSON(fiber.Map{"schedule": schedule, "active": schedule != ""})
 }
@@ -91,10 +90,10 @@ func (s *HTTPServer) updateDeleteReaperSchedule(c *fiber.Ctx) error {
 		Schedule string `json:"schedule"`
 	}
 	if err := c.BodyParser(&req); err != nil {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid request body"})
+		return jsonError(c, fiber.StatusBadRequest, "invalid request body")
 	}
 	if err := s.queueService.UpdateDeleteReaperSchedule(c.Context(), req.Schedule); err != nil {
-		return c.Status(fiber.StatusUnprocessableEntity).JSON(fiber.Map{"error": err.Error()})
+		return jsonError(c, fiber.StatusUnprocessableEntity, err.Error())
 	}
 	return c.JSON(fiber.Map{"schedule": req.Schedule, "active": req.Schedule != ""})
 }

--- a/internal/server/handlers_auth.go
+++ b/internal/server/handlers_auth.go
@@ -22,21 +22,21 @@ type tokenResponse struct {
 func (s *HTTPServer) handleLogin(c *fiber.Ctx) error {
 	var req loginRequest
 	if err := c.BodyParser(&req); err != nil || req.Username == "" || req.Password == "" {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "username and password are required"})
+		return jsonError(c, fiber.StatusBadRequest, "username and password are required")
 	}
 	user, hash, err := s.userStore.GetByUsername(c.Context(), req.Username)
 	if errors.Is(err, users.ErrNotFound) {
-		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "invalid credentials"})
+		return jsonError(c, fiber.StatusUnauthorized, "invalid credentials")
 	}
 	if err != nil {
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal error"})
+		return jsonError(c, fiber.StatusInternalServerError, "internal error")
 	}
 	if bcrypt.CompareHashAndPassword([]byte(hash), []byte(req.Password)) != nil {
-		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "invalid credentials"})
+		return jsonError(c, fiber.StatusUnauthorized, "invalid credentials")
 	}
 	token, err := users.IssueToken([]byte(s.authConfig.JWTSecret), user.ID, user.Username, user.IsAdmin)
 	if err != nil {
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to issue token"})
+		return jsonError(c, fiber.StatusInternalServerError, "failed to issue token")
 	}
 	return c.JSON(tokenResponse{Token: token})
 }
@@ -44,18 +44,18 @@ func (s *HTTPServer) handleLogin(c *fiber.Ctx) error {
 func (s *HTTPServer) handleRefresh(c *fiber.Ctx) error {
 	claims := internalAuth.ClaimsFromCtx(c)
 	if claims == nil {
-		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "not authenticated"})
+		return jsonError(c, fiber.StatusUnauthorized, "not authenticated")
 	}
 	user, err := s.userStore.GetByID(c.Context(), claims.UserID)
 	if errors.Is(err, users.ErrNotFound) {
-		return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "user no longer exists"})
+		return jsonError(c, fiber.StatusUnauthorized, "user no longer exists")
 	}
 	if err != nil {
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal error"})
+		return jsonError(c, fiber.StatusInternalServerError, "internal error")
 	}
 	token, err := users.IssueToken([]byte(s.authConfig.JWTSecret), user.ID, user.Username, user.IsAdmin)
 	if err != nil {
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to issue token"})
+		return jsonError(c, fiber.StatusInternalServerError, "failed to issue token")
 	}
 	return c.JSON(tokenResponse{Token: token})
 }

--- a/internal/server/handlers_messages.go
+++ b/internal/server/handlers_messages.go
@@ -91,7 +91,7 @@ func toMessageResponse(m queue.Message) messageResponse {
 
 func (s *HTTPServer) listMessages(c *fiber.Ctx) error {
 	topic := c.Query("topic")
-	limit, offset, _ := parseLimitOffset(c, 50, 200)
+	limit, offset := parseLimitOffset(c, 50, 200)
 
 	result, err := s.queueService.List(c.Context(), topic, limit, offset)
 	if err != nil {

--- a/internal/server/handlers_messages.go
+++ b/internal/server/handlers_messages.go
@@ -91,30 +91,22 @@ func toMessageResponse(m queue.Message) messageResponse {
 
 func (s *HTTPServer) listMessages(c *fiber.Ctx) error {
 	topic := c.Query("topic")
+	limit, offset, _ := parseLimitOffset(c, 50, 200)
 
-	limit := c.QueryInt("limit", 50)
-	if limit < 1 {
-		limit = 1
-	} else if limit > 200 {
-		limit = 200
-	}
-
-	offset := max(c.QueryInt("offset", 0), 0)
-
-	messages, total, err := s.queueService.List(c.Context(), topic, limit, offset)
+	result, err := s.queueService.List(c.Context(), topic, limit, offset)
 	if err != nil {
 		slog.Error("list messages failed", "topic", topic, "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
+		return jsonError(c, fiber.StatusInternalServerError, "internal server error")
 	}
 
-	items := make([]messageResponse, 0, len(messages))
-	for _, m := range messages {
+	items := make([]messageResponse, 0, len(result.Items))
+	for _, m := range result.Items {
 		items = append(items, toMessageResponse(m))
 	}
 
 	return c.JSON(listResponse{
 		Items:  items,
-		Total:  total,
+		Total:  result.Total,
 		Limit:  limit,
 		Offset: offset,
 	})
@@ -123,26 +115,26 @@ func (s *HTTPServer) listMessages(c *fiber.Ctx) error {
 func (s *HTTPServer) enqueueMessage(c *fiber.Ctx) error {
 	var req enqueueRequest
 	if err := c.BodyParser(&req); err != nil {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid request body"})
+		return jsonError(c, fiber.StatusBadRequest, "invalid request body")
 	}
 
 	if req.Topic == "" || req.Payload == "" {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "topic and payload are required"})
+		return jsonError(c, fiber.StatusBadRequest, "topic and payload are required")
 	}
 
 	id, err := s.queueService.Enqueue(c.Context(), req.Topic, []byte(req.Payload), req.Metadata, req.Key)
 	if err != nil {
 		if errors.Is(err, queue.ErrSchemaValidation) {
-			return c.Status(fiber.StatusUnprocessableEntity).JSON(fiber.Map{"error": err.Error()})
+			return jsonError(c, fiber.StatusUnprocessableEntity, err.Error())
 		}
 		if errors.Is(err, queue.ErrTopicNotRegistered) {
-			return c.Status(fiber.StatusUnprocessableEntity).JSON(fiber.Map{"error": err.Error()})
+			return jsonError(c, fiber.StatusUnprocessableEntity, err.Error())
 		}
 		if errors.Is(err, queue.ErrQueueFull) {
-			return c.Status(fiber.StatusTooManyRequests).JSON(fiber.Map{"error": err.Error()})
+			return jsonError(c, fiber.StatusTooManyRequests, err.Error())
 		}
 		slog.Error("enqueue failed", "topic", req.Topic, "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
+		return jsonError(c, fiber.StatusInternalServerError, "internal server error")
 	}
 
 	return c.Status(fiber.StatusCreated).JSON(fiber.Map{"id": id})
@@ -151,11 +143,11 @@ func (s *HTTPServer) enqueueMessage(c *fiber.Ctx) error {
 func (s *HTTPServer) batchDequeueMessages(c *fiber.Ctx) error {
 	var req batchDequeueRequest
 	if err := c.BodyParser(&req); err != nil {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid request body"})
+		return jsonError(c, fiber.StatusBadRequest, "invalid request body")
 	}
 
 	if req.Topic == "" {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "topic is required"})
+		return jsonError(c, fiber.StatusBadRequest, "topic is required")
 	}
 
 	if req.Count == 0 {
@@ -163,7 +155,7 @@ func (s *HTTPServer) batchDequeueMessages(c *fiber.Ctx) error {
 	}
 
 	if req.Count < 1 || req.Count > 1000 {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "count must be between 1 and 1000"})
+		return jsonError(c, fiber.StatusBadRequest, "count must be between 1 and 1000")
 	}
 
 	var vt time.Duration
@@ -174,10 +166,10 @@ func (s *HTTPServer) batchDequeueMessages(c *fiber.Ctx) error {
 	batch, err := s.queueService.DequeueN(c.Context(), req.Topic, req.Count, vt)
 	if err != nil {
 		if errors.Is(err, queue.ErrInvalidBatchSize) {
-			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": err.Error()})
+			return jsonError(c, fiber.StatusBadRequest, err.Error())
 		}
 		slog.Error("batch dequeue failed", "topic", req.Topic, "count", req.Count, "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
+		return jsonError(c, fiber.StatusInternalServerError, "internal server error")
 	}
 
 	items := make([]messageResponse, 0, len(batch))
@@ -197,10 +189,10 @@ func (s *HTTPServer) nackMessage(c *fiber.Ctx) error {
 
 	if err := s.queueService.Nack(c.Context(), id, req.Error); err != nil {
 		if errors.Is(err, queue.ErrNotFound) || errors.Is(err, queue.ErrNotProcessing) {
-			return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": err.Error()})
+			return jsonError(c, fiber.StatusNotFound, err.Error())
 		}
 		slog.Error("nack failed", "id", id, "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
+		return jsonError(c, fiber.StatusInternalServerError, "internal server error")
 	}
 
 	return c.SendStatus(fiber.StatusNoContent)
@@ -210,7 +202,7 @@ func (s *HTTPServer) statsHandler(c *fiber.Ctx) error {
 	stats, err := s.queueService.Stats(c.Context())
 	if err != nil {
 		slog.Error("stats failed", "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
+		return jsonError(c, fiber.StatusInternalServerError, "internal server error")
 	}
 	items := make([]topicStatResponse, len(stats))
 	for i, st := range stats {
@@ -224,10 +216,10 @@ func (s *HTTPServer) requeueMessage(c *fiber.Ctx) error {
 
 	if err := s.queueService.Requeue(c.Context(), id); err != nil {
 		if errors.Is(err, queue.ErrNotFound) || errors.Is(err, queue.ErrNotDLQ) {
-			return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": err.Error()})
+			return jsonError(c, fiber.StatusNotFound, err.Error())
 		}
 		slog.Error("requeue failed", "id", id, "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
+		return jsonError(c, fiber.StatusInternalServerError, "internal server error")
 	}
 
 	return c.SendStatus(fiber.StatusNoContent)

--- a/internal/server/handlers_replay.go
+++ b/internal/server/handlers_replay.go
@@ -74,7 +74,7 @@ func (s *HTTPServer) replayTopic(c *fiber.Ctx) error {
 
 func (s *HTTPServer) listMessageLog(c *fiber.Ctx) error {
 	topic := c.Params("topic")
-	limit, offset, _ := parseLimitOffset(c, 50, 200)
+	limit, offset := parseLimitOffset(c, 50, 200)
 
 	result, err := s.queueService.ListMessageLog(c.Context(), topic, limit, offset)
 	if err != nil {

--- a/internal/server/handlers_replay.go
+++ b/internal/server/handlers_replay.go
@@ -44,7 +44,7 @@ func (s *HTTPServer) replayTopic(c *fiber.Ctx) error {
 
 	var req replayRequest
 	if err := c.BodyParser(&req); err != nil {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid request body"})
+		return jsonError(c, fiber.StatusBadRequest, "invalid request body")
 	}
 
 	var fromTime time.Time
@@ -52,17 +52,17 @@ func (s *HTTPServer) replayTopic(c *fiber.Ctx) error {
 		var err error
 		fromTime, err = time.Parse(time.RFC3339, *req.FromTime)
 		if err != nil {
-			return c.Status(fiber.StatusUnprocessableEntity).JSON(fiber.Map{"error": "from_time must be RFC 3339"})
+			return jsonError(c, fiber.StatusUnprocessableEntity, "from_time must be RFC 3339")
 		}
 	}
 
 	n, err := s.queueService.ReplayTopic(c.Context(), topic, fromTime)
 	if err != nil {
 		if errors.Is(err, queue.ErrTopicNotReplayable) || errors.Is(err, queue.ErrReplayWindowTooOld) {
-			return c.Status(fiber.StatusUnprocessableEntity).JSON(fiber.Map{"error": err.Error()})
+			return jsonError(c, fiber.StatusUnprocessableEntity, err.Error())
 		}
 		slog.Error("replay topic failed", "topic", topic, "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
+		return jsonError(c, fiber.StatusInternalServerError, "internal server error")
 	}
 
 	fromStr := ""
@@ -74,23 +74,16 @@ func (s *HTTPServer) replayTopic(c *fiber.Ctx) error {
 
 func (s *HTTPServer) listMessageLog(c *fiber.Ctx) error {
 	topic := c.Params("topic")
-	limit := c.QueryInt("limit", 50)
-	if limit <= 0 {
-		limit = 50
-	}
-	if limit > 200 {
-		limit = 200
-	}
-	offset := c.QueryInt("offset", 0)
+	limit, offset, _ := parseLimitOffset(c, 50, 200)
 
-	msgs, total, err := s.queueService.ListMessageLog(c.Context(), topic, limit, offset)
+	result, err := s.queueService.ListMessageLog(c.Context(), topic, limit, offset)
 	if err != nil {
 		slog.Error("list message log failed", "topic", topic, "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
+		return jsonError(c, fiber.StatusInternalServerError, "internal server error")
 	}
 
-	items := make([]archivedMessageResponse, len(msgs))
-	for i, m := range msgs {
+	items := make([]archivedMessageResponse, len(result.Items))
+	for i, m := range result.Items {
 		items[i] = archivedMessageResponse{
 			ID:            m.ID,
 			Topic:         m.Topic,
@@ -102,14 +95,14 @@ func (s *HTTPServer) listMessageLog(c *fiber.Ctx) error {
 			AckedAt:       m.AckedAt.UTC().Format(time.RFC3339),
 		}
 	}
-	return c.JSON(messageLogResponse{Items: items, Total: total, Limit: limit, Offset: offset})
+	return c.JSON(messageLogResponse{Items: items, Total: result.Total, Limit: limit, Offset: offset})
 }
 
 func (s *HTTPServer) runArchiveReaperOnce(c *fiber.Ctx) error {
 	n, err := s.queueService.RunArchiveReaperOnce(c.Context())
 	if err != nil {
 		slog.Error("archive reaper (manual) failed", "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
+		return jsonError(c, fiber.StatusInternalServerError, "internal server error")
 	}
 	return c.JSON(fiber.Map{"deleted": n})
 }
@@ -118,17 +111,17 @@ func (s *HTTPServer) trimMessageLog(c *fiber.Ctx) error {
 	topic := c.Params("topic")
 	beforeStr := c.Query("before")
 	if beforeStr == "" {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "before query parameter is required"})
+		return jsonError(c, fiber.StatusBadRequest, "before query parameter is required")
 	}
 	before, err := time.Parse(time.RFC3339, beforeStr)
 	if err != nil {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "before must be RFC 3339"})
+		return jsonError(c, fiber.StatusBadRequest, "before must be RFC 3339")
 	}
 
 	n, err := s.queueService.TrimMessageLog(c.Context(), topic, before)
 	if err != nil {
 		slog.Error("trim message log failed", "topic", topic, "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
+		return jsonError(c, fiber.StatusInternalServerError, "internal server error")
 	}
 	return c.JSON(fiber.Map{"deleted": n})
 }

--- a/internal/server/handlers_topic_config.go
+++ b/internal/server/handlers_topic_config.go
@@ -3,7 +3,6 @@ package server
 import (
 	"errors"
 	"log/slog"
-	"strings"
 
 	"github.com/gofiber/fiber/v2"
 
@@ -49,7 +48,7 @@ func (s *HTTPServer) listTopicConfigs(c *fiber.Ctx) error {
 	configs, err := s.queueService.ListTopicConfigs(c.Context())
 	if err != nil {
 		slog.Error("list topic configs failed", "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
+		return jsonError(c, fiber.StatusInternalServerError, "internal server error")
 	}
 	items := make([]topicConfigResponse, len(configs))
 	for i, cfg := range configs {
@@ -60,17 +59,14 @@ func (s *HTTPServer) listTopicConfigs(c *fiber.Ctx) error {
 
 func (s *HTTPServer) upsertTopicConfig(c *fiber.Ctx) error {
 	topic := c.Params("topic")
-	if strings.HasSuffix(topic, ".dlq") {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "topic name may not end in .dlq"})
-	}
 
 	var req topicConfigRequest
 	if err := c.BodyParser(&req); err != nil {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid request body"})
+		return jsonError(c, fiber.StatusBadRequest, "invalid request body")
 	}
 
 	if req.ThroughputLimit != nil && *req.ThroughputLimit < 0 {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "throughput_limit must be a non-negative integer"})
+		return jsonError(c, fiber.StatusBadRequest, "throughput_limit must be a non-negative integer")
 	}
 
 	replayable := false
@@ -91,8 +87,11 @@ func (s *HTTPServer) upsertTopicConfig(c *fiber.Ctx) error {
 		ThroughputLimit:     req.ThroughputLimit,
 	}
 	if err := s.queueService.UpsertTopicConfig(c.Context(), cfg); err != nil {
+		if errors.Is(err, queue.ErrReservedTopic) {
+			return jsonError(c, fiber.StatusBadRequest, "topic name may not end in .dlq")
+		}
 		slog.Error("upsert topic config failed", "topic", topic, "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
+		return jsonError(c, fiber.StatusInternalServerError, "internal server error")
 	}
 	return c.JSON(toTopicConfigResponse(cfg))
 }
@@ -101,10 +100,10 @@ func (s *HTTPServer) deleteTopicConfig(c *fiber.Ctx) error {
 	topic := c.Params("topic")
 	if err := s.queueService.DeleteTopicConfig(c.Context(), topic); err != nil {
 		if errors.Is(err, queue.ErrNotFound) {
-			return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": err.Error()})
+			return jsonError(c, fiber.StatusNotFound, err.Error())
 		}
 		slog.Error("delete topic config failed", "topic", topic, "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
+		return jsonError(c, fiber.StatusInternalServerError, "internal server error")
 	}
 	return c.SendStatus(fiber.StatusNoContent)
 }

--- a/internal/server/handlers_topic_schema.go
+++ b/internal/server/handlers_topic_schema.go
@@ -37,7 +37,7 @@ func (s *HTTPServer) listTopicSchemas(c *fiber.Ctx) error {
 	schemas, err := queue.ListTopicSchemas(c.Context(), s.queueService.Pool())
 	if err != nil {
 		slog.Error("list topic schemas failed", "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
+		return jsonError(c, fiber.StatusInternalServerError, "internal server error")
 	}
 	items := make([]topicSchemaResponse, len(schemas))
 	for i, ts := range schemas {
@@ -51,16 +51,16 @@ func (s *HTTPServer) upsertTopicSchema(c *fiber.Ctx) error {
 
 	var req topicSchemaRequest
 	if err := c.BodyParser(&req); err != nil {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid request body"})
+		return jsonError(c, fiber.StatusBadRequest, "invalid request body")
 	}
 
 	ts, err := queue.UpsertTopicSchema(c.Context(), s.queueService.Pool(), topic, req.SchemaJSON)
 	if err != nil {
 		if errors.Is(err, queue.ErrInvalidSchema) {
-			return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": err.Error()})
+			return jsonError(c, fiber.StatusBadRequest, err.Error())
 		}
 		slog.Error("upsert topic schema failed", "topic", topic, "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
+		return jsonError(c, fiber.StatusInternalServerError, "internal server error")
 	}
 	return c.JSON(toTopicSchemaResponse(*ts))
 }
@@ -69,7 +69,7 @@ func (s *HTTPServer) deleteTopicSchema(c *fiber.Ctx) error {
 	topic := c.Params("topic")
 	if err := queue.DeleteTopicSchema(c.Context(), s.queueService.Pool(), topic); err != nil {
 		slog.Error("delete topic schema failed", "topic", topic, "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
+		return jsonError(c, fiber.StatusInternalServerError, "internal server error")
 	}
 	return c.SendStatus(fiber.StatusNoContent)
 }
@@ -79,10 +79,10 @@ func (s *HTTPServer) getTopicSchema(c *fiber.Ctx) error {
 	ts, err := queue.GetTopicSchema(c.Context(), s.queueService.Pool(), topic)
 	if err != nil {
 		slog.Error("get topic schema failed", "topic", topic, "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
+		return jsonError(c, fiber.StatusInternalServerError, "internal server error")
 	}
 	if ts == nil {
-		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": "schema not found"})
+		return jsonError(c, fiber.StatusNotFound, "schema not found")
 	}
 	return c.JSON(toTopicSchemaResponse(*ts))
 }

--- a/internal/server/handlers_users.go
+++ b/internal/server/handlers_users.go
@@ -67,7 +67,7 @@ func (s *HTTPServer) listUsers(c *fiber.Ctx) error {
 	list, err := s.userStore.List(c.Context())
 	if err != nil {
 		slog.Error("list users failed", "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
+		return jsonError(c, fiber.StatusInternalServerError, "internal server error")
 	}
 	items := make([]userResponse, len(list))
 	for i, u := range list {
@@ -79,21 +79,21 @@ func (s *HTTPServer) listUsers(c *fiber.Ctx) error {
 func (s *HTTPServer) createUser(c *fiber.Ctx) error {
 	var req createUserRequest
 	if err := c.BodyParser(&req); err != nil {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid request body"})
+		return jsonError(c, fiber.StatusBadRequest, "invalid request body")
 	}
 	if req.Username == "" || req.Password == "" {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "username and password are required"})
+		return jsonError(c, fiber.StatusBadRequest, "username and password are required")
 	}
 	if len(req.Password) < 12 {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "password must be at least 12 characters"})
+		return jsonError(c, fiber.StatusBadRequest, "password must be at least 12 characters")
 	}
 	u, err := s.userStore.Create(c.Context(), req.Username, req.Password, req.IsAdmin)
 	if errors.Is(err, users.ErrDuplicate) {
-		return c.Status(fiber.StatusConflict).JSON(fiber.Map{"error": err.Error()})
+		return jsonError(c, fiber.StatusConflict, err.Error())
 	}
 	if err != nil {
 		slog.Error("create user failed", "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
+		return jsonError(c, fiber.StatusInternalServerError, "internal server error")
 	}
 	return c.Status(fiber.StatusCreated).JSON(toUserResponse(u))
 }
@@ -102,21 +102,21 @@ func (s *HTTPServer) updateUser(c *fiber.Ctx) error {
 	id := c.Params("id")
 	var req updateUserRequest
 	if err := c.BodyParser(&req); err != nil {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid request body"})
+		return jsonError(c, fiber.StatusBadRequest, "invalid request body")
 	}
 	if req.Password != nil && len(*req.Password) < 12 {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "password must be at least 12 characters"})
+		return jsonError(c, fiber.StatusBadRequest, "password must be at least 12 characters")
 	}
 	u, err := s.userStore.Update(c.Context(), id, req.Username, req.Password, req.IsAdmin)
 	if errors.Is(err, users.ErrNotFound) {
-		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": err.Error()})
+		return jsonError(c, fiber.StatusNotFound, err.Error())
 	}
 	if errors.Is(err, users.ErrDuplicate) {
-		return c.Status(fiber.StatusConflict).JSON(fiber.Map{"error": err.Error()})
+		return jsonError(c, fiber.StatusConflict, err.Error())
 	}
 	if err != nil {
 		slog.Error("update user failed", "id", id, "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
+		return jsonError(c, fiber.StatusInternalServerError, "internal server error")
 	}
 	return c.JSON(toUserResponse(u))
 }
@@ -129,14 +129,14 @@ func (s *HTTPServer) deleteUser(c *fiber.Ctx) error {
 	}
 	err := s.userStore.Delete(c.Context(), id, callerID)
 	if errors.Is(err, users.ErrCannotDeleteSelf) {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": err.Error()})
+		return jsonError(c, fiber.StatusBadRequest, err.Error())
 	}
 	if errors.Is(err, users.ErrNotFound) {
-		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": err.Error()})
+		return jsonError(c, fiber.StatusNotFound, err.Error())
 	}
 	if err != nil {
 		slog.Error("delete user failed", "id", id, "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
+		return jsonError(c, fiber.StatusInternalServerError, "internal server error")
 	}
 	return c.SendStatus(fiber.StatusNoContent)
 }
@@ -146,7 +146,7 @@ func (s *HTTPServer) listUserGrants(c *fiber.Ctx) error {
 	grants, err := s.userStore.ListGrants(c.Context(), userID)
 	if err != nil {
 		slog.Error("list user grants failed", "user_id", userID, "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
+		return jsonError(c, fiber.StatusInternalServerError, "internal server error")
 	}
 	items := make([]grantResponse, len(grants))
 	for i, g := range grants {
@@ -159,10 +159,10 @@ func (s *HTTPServer) addUserGrant(c *fiber.Ctx) error {
 	userID := c.Params("id")
 	var req addGrantRequest
 	if err := c.BodyParser(&req); err != nil {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "invalid request body"})
+		return jsonError(c, fiber.StatusBadRequest, "invalid request body")
 	}
 	if req.Action != "read" && req.Action != "write" && req.Action != "admin" {
-		return c.Status(fiber.StatusBadRequest).JSON(fiber.Map{"error": "action must be one of: read, write, admin"})
+		return jsonError(c, fiber.StatusBadRequest, "action must be one of: read, write, admin")
 	}
 	topicPattern := req.TopicPattern
 	if topicPattern == "" {
@@ -171,7 +171,7 @@ func (s *HTTPServer) addUserGrant(c *fiber.Ctx) error {
 	g, err := s.userStore.AddGrant(c.Context(), userID, req.Action, topicPattern)
 	if err != nil {
 		slog.Error("add user grant failed", "user_id", userID, "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
+		return jsonError(c, fiber.StatusInternalServerError, "internal server error")
 	}
 	return c.Status(fiber.StatusCreated).JSON(toGrantResponse(g))
 }
@@ -181,11 +181,11 @@ func (s *HTTPServer) deleteUserGrant(c *fiber.Ctx) error {
 	grantID := c.Params("grantId")
 	err := s.userStore.DeleteGrant(c.Context(), grantID, userID)
 	if errors.Is(err, users.ErrNotFound) {
-		return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": err.Error()})
+		return jsonError(c, fiber.StatusNotFound, err.Error())
 	}
 	if err != nil {
 		slog.Error("delete user grant failed", "user_id", userID, "grant_id", grantID, "error", err)
-		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "internal server error"})
+		return jsonError(c, fiber.StatusInternalServerError, "internal server error")
 	}
 	return c.SendStatus(fiber.StatusNoContent)
 }

--- a/internal/server/helpers.go
+++ b/internal/server/helpers.go
@@ -9,12 +9,11 @@ func jsonError(c *fiber.Ctx, status int, msg string) error {
 	return c.Status(status).JSON(fiber.Map{"error": msg})
 }
 
-// parseLimitOffset extracts and clamps the "limit" and "offset" query parameters
-// from the request. limit is clamped to [1, maxLimit] and defaults to
-// defaultLimit when absent or zero. offset is clamped to [0, ∞) and defaults
-// to 0. The returned error is always nil — invalid values are silently clamped
-// rather than rejected, matching the existing handler behaviour.
-func parseLimitOffset(c *fiber.Ctx, defaultLimit, maxLimit int) (limit, offset int, err error) {
+// parseLimitOffset extracts and clamps the "limit" and "offset" query parameters.
+// limit is clamped to [1, maxLimit] and defaults to defaultLimit when absent or
+// zero. offset is clamped to [0, ∞). Invalid values are silently clamped rather
+// than rejected, matching the existing handler behaviour.
+func parseLimitOffset(c *fiber.Ctx, defaultLimit, maxLimit int) (limit, offset int) {
 	limit = c.QueryInt("limit", defaultLimit)
 	if limit < 1 {
 		limit = 1
@@ -22,5 +21,5 @@ func parseLimitOffset(c *fiber.Ctx, defaultLimit, maxLimit int) (limit, offset i
 		limit = maxLimit
 	}
 	offset = max(c.QueryInt("offset", 0), 0)
-	return limit, offset, nil
+	return limit, offset
 }

--- a/internal/server/helpers.go
+++ b/internal/server/helpers.go
@@ -1,0 +1,26 @@
+package server
+
+import "github.com/gofiber/fiber/v2"
+
+// jsonError writes a JSON error response with the given HTTP status code.
+// It is the single canonical way to return an error from any HTTP handler,
+// eliminating the repeated c.Status(N).JSON(fiber.Map{"error": "..."}) pattern.
+func jsonError(c *fiber.Ctx, status int, msg string) error {
+	return c.Status(status).JSON(fiber.Map{"error": msg})
+}
+
+// parseLimitOffset extracts and clamps the "limit" and "offset" query parameters
+// from the request. limit is clamped to [1, maxLimit] and defaults to
+// defaultLimit when absent or zero. offset is clamped to [0, ∞) and defaults
+// to 0. The returned error is always nil — invalid values are silently clamped
+// rather than rejected, matching the existing handler behaviour.
+func parseLimitOffset(c *fiber.Ctx, defaultLimit, maxLimit int) (limit, offset int, err error) {
+	limit = c.QueryInt("limit", defaultLimit)
+	if limit < 1 {
+		limit = 1
+	} else if limit > maxLimit {
+		limit = maxLimit
+	}
+	offset = max(c.QueryInt("offset", 0), 0)
+	return limit, offset, nil
+}

--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -7,41 +7,60 @@ import (
 	"github.com/Joessst-Dev/queue-ti/internal/users"
 )
 
+// Middleware error message constants — centralised here so that any change to
+// the wording is applied consistently across all middleware functions and tests
+// that assert on these strings.
+const (
+	errMsgAuthRequired        = "authentication required"
+	errMsgAdminRequired       = "admin access required"
+	errMsgInsufficientPerms   = "insufficient permissions"
+	errMsgFailedCheckPerms    = "failed to check permissions"
+	errMsgMessageNotFound     = "message not found"
+)
+
+// checkAuthAndAdmin is the shared preamble for every middleware in this file.
+// It returns (done=true, err) when the middleware should stop processing:
+//   - done=true, err=401 response  — auth is enabled but caller has no claims
+//   - done=true, err=nil           — caller is an admin; skip further grant checks
+//
+// When done=false the caller must continue with its own grant logic.
+func (s *HTTPServer) checkAuthAndAdmin(c *fiber.Ctx) (done bool, err error) {
+	claims := internalAuth.ClaimsFromCtx(c)
+	if s.authConfig.Enabled && claims == nil {
+		return true, jsonError(c, fiber.StatusUnauthorized, errMsgAuthRequired)
+	}
+	if claims == nil {
+		// Auth disabled — pass through unconditionally.
+		return true, c.Next()
+	}
+	if claims.IsAdmin {
+		return true, c.Next()
+	}
+	return false, nil
+}
+
 func (s *HTTPServer) requireAdmin() fiber.Handler {
 	return func(c *fiber.Ctx) error {
-		claims := internalAuth.ClaimsFromCtx(c)
-		if s.authConfig.Enabled && claims == nil {
-			return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "authentication required"})
+		if done, err := s.checkAuthAndAdmin(c); done {
+			return err
 		}
-		if claims == nil {
-			return c.Next()
-		}
-		if claims.IsAdmin {
-			return c.Next()
-		}
-		return c.Status(fiber.StatusForbidden).JSON(fiber.Map{"error": "admin access required"})
+		return jsonError(c, fiber.StatusForbidden, errMsgAdminRequired)
 	}
 }
 
 func (s *HTTPServer) requireGrant(action string, topicFn func(*fiber.Ctx) string) fiber.Handler {
 	return func(c *fiber.Ctx) error {
+		if done, err := s.checkAuthAndAdmin(c); done {
+			return err
+		}
 		claims := internalAuth.ClaimsFromCtx(c)
-		if s.authConfig.Enabled && claims == nil {
-			return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "authentication required"})
-		}
-		if claims == nil {
-			return c.Next()
-		}
-		if claims.IsAdmin {
-			return c.Next()
-		}
 		topic := topicFn(c)
 		grants, err := s.userStore.GetUserGrants(c.Context(), claims.UserID)
 		if err != nil {
-			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to check permissions"})
+			return jsonError(c, fiber.StatusInternalServerError, errMsgFailedCheckPerms)
 		}
 		if !users.HasGrant(grants, action, topic) {
-			return c.Status(fiber.StatusForbidden).JSON(fiber.Map{"error": "insufficient permissions"})
+			return jsonError(c, fiber.StatusForbidden, errMsgInsufficientPerms)
 		}
 		return c.Next()
 	}
@@ -49,27 +68,21 @@ func (s *HTTPServer) requireGrant(action string, topicFn func(*fiber.Ctx) string
 
 func (s *HTTPServer) requireWriteOnMsgTopic() fiber.Handler {
 	return func(c *fiber.Ctx) error {
+		if done, err := s.checkAuthAndAdmin(c); done {
+			return err
+		}
 		claims := internalAuth.ClaimsFromCtx(c)
-		if s.authConfig.Enabled && claims == nil {
-			return c.Status(fiber.StatusUnauthorized).JSON(fiber.Map{"error": "authentication required"})
-		}
-		if claims == nil {
-			return c.Next()
-		}
-		if claims.IsAdmin {
-			return c.Next()
-		}
 		id := c.Params("id")
 		topic, err := s.queueService.TopicForMessage(c.Context(), id)
 		if err != nil {
-			return c.Status(fiber.StatusNotFound).JSON(fiber.Map{"error": "message not found"})
+			return jsonError(c, fiber.StatusNotFound, errMsgMessageNotFound)
 		}
 		grants, err := s.userStore.GetUserGrants(c.Context(), claims.UserID)
 		if err != nil {
-			return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "failed to check permissions"})
+			return jsonError(c, fiber.StatusInternalServerError, errMsgFailedCheckPerms)
 		}
 		if !users.HasGrant(grants, "write", topic) {
-			return c.Status(fiber.StatusForbidden).JSON(fiber.Map{"error": "insufficient permissions"})
+			return jsonError(c, fiber.StatusForbidden, errMsgInsufficientPerms)
 		}
 		return c.Next()
 	}


### PR DESCRIPTION
## Summary
- Add `jsonError` / `parseLimitOffset` helpers in `internal/server/helpers.go` to eliminate repeated `c.Status(N).JSON(fiber.Map{...})` and query-param parsing boilerplate across all HTTP handlers
- Extract `checkAuthAndAdmin` shared preamble in `middleware.go` and centralise error message strings as constants
- Extract `resolveVisibilityTimeout` in `dequeue.go` and `grpc.go`
- Extract `runDeleteWork` inner loop in `reaper.go`
- Guard `.dlq` suffix in `UpsertTopicConfig`

## Test plan
- [x] `make test` passes (all 8 Ginkgo suites)
- [x] No behaviour change — all existing HTTP handler tests pass unchanged