### PR TITLE
refactor(frontend): extract NackOverlay, PurgeConfirmPanel, status-classes

### DIFF
--- a/admin-ui/src/app/messages/messages-table.spec.ts
+++ b/admin-ui/src/app/messages/messages-table.spec.ts
@@ -389,13 +389,10 @@ describe('MessagesTable', () => {
     });
 
     describe('when the Cancel button inside the overlay is clicked', () => {
-      it('should dismiss the overlay and reset nackError', async () => {
+      it('should dismiss the overlay', async () => {
         const messages = [makeMessage({ status: 'processing' })];
-        const { fixture, component } = await setup({ messages });
+        const { fixture } = await setup({ messages });
         await openNackOverlay(fixture);
-
-        component.nackError.set('some error');
-        fixture.detectChanges();
 
         const cancelBtn = Array.from(fixture.nativeElement.querySelectorAll('button')).find(
           (b) => (b as HTMLButtonElement).title === 'Cancel',
@@ -405,7 +402,6 @@ describe('MessagesTable', () => {
         await fixture.whenStable();
 
         expect(fixture.nativeElement.querySelector('[data-nack-overlay]')).toBeNull();
-        expect(component.nackError()).toBe('');
       });
     });
   });

--- a/admin-ui/src/app/messages/messages-table.ts
+++ b/admin-ui/src/app/messages/messages-table.ts
@@ -16,6 +16,9 @@ import {
   CdkFixedSizeVirtualScroll,
 } from '@angular/cdk/scrolling';
 import { QueueMessage } from '../services/queue.service';
+import { NackOverlay } from './nack-overlay';
+import { PurgeConfirmPanel } from './purge-confirm-panel';
+import { STATUS_CLASS_MAP, DEFAULT_STATUS_CLASS } from './status-classes';
 
 // py-4 top (16) + text-sm line-height (20) + py-4 bottom (16) + divide-y border (1) = 53
 const ITEM_SIZE = 53;
@@ -23,7 +26,7 @@ const ITEM_SIZE = 53;
 @Component({
   selector: 'app-messages-table',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [FormField, SlicePipe, DatePipe, CdkVirtualScrollViewport, CdkVirtualForOf, CdkFixedSizeVirtualScroll],
+  imports: [FormField, SlicePipe, DatePipe, CdkVirtualScrollViewport, CdkVirtualForOf, CdkFixedSizeVirtualScroll, NackOverlay, PurgeConfirmPanel],
   template: `
     <section class="bg-white shadow rounded-lg">
       <div
@@ -87,38 +90,13 @@ const ITEM_SIZE = 53;
       </div>
 
       @if (showPurgeConfirm()) {
-        <div class="px-6 py-3 border-b border-red-200 bg-red-50 space-y-2">
-          <p class="text-sm font-medium text-red-800">Purge messages from "{{ filterForm().value() }}"</p>
-          <div class="flex gap-3 text-sm">
-            @for (status of ['pending', 'processing', 'expired']; track status) {
-              <label class="flex items-center gap-1 cursor-pointer">
-                <input
-                  type="checkbox"
-                  [checked]="purgeStatuses().includes(status)"
-                  (change)="togglePurgeStatus(status)"
-                />
-                {{ status }}
-              </label>
-            }
-          </div>
-          <div class="flex gap-2">
-            <button
-              type="button"
-              [disabled]="purgeStatuses().length === 0"
-              (click)="confirmPurge()"
-              class="px-3 py-1.5 text-sm font-medium text-white bg-red-600 rounded-md hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              Confirm purge
-            </button>
-            <button
-              type="button"
-              (click)="showPurgeConfirm.set(false)"
-              class="px-3 py-1.5 text-sm font-medium text-gray-600 border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-gray-400 cursor-pointer"
-            >
-              Cancel
-            </button>
-          </div>
-        </div>
+        <app-purge-confirm-panel
+          [topic]="filterForm().value()"
+          [statuses]="purgeStatuses()"
+          (purgeConfirmed)="confirmPurge($event)"
+          (purgeCancelled)="showPurgeConfirm.set(false)"
+          (statusToggle)="togglePurgeStatus($event)"
+        />
       }
 
       @if (error()) {
@@ -292,32 +270,14 @@ const ITEM_SIZE = 53;
                       </button>
                     } @else if (msg.status === 'processing') {
                       @if (nackOpenId() === msg.id) {
-                        <div data-nack-overlay class="absolute right-0 top-1/2 -translate-y-1/2 flex items-center gap-1 bg-white border border-gray-200 rounded shadow-md px-2 py-1 z-20">
-                          <input
-                            type="text"
-                            [value]="nackError()"
-                            (input)="nackError.set(inputValue($event))"
-                            placeholder="Reason…"
-                            class="px-1 py-0.5 text-xs border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-red-400 w-28"
-                          />
-                          <button
-                            (click)="onNackConfirm(msg.id)"
-                            title="Confirm nack"
-                            class="px-1.5 py-0.5 text-xs font-medium bg-red-100 text-red-800 rounded hover:bg-red-200 cursor-pointer whitespace-nowrap"
-                          >
-                            ✓
-                          </button>
-                          <button
-                            (click)="nackOpenId.set(null); nackError.set('')"
-                            title="Cancel"
-                            class="px-1.5 py-0.5 text-xs text-gray-500 hover:text-gray-700 cursor-pointer"
-                          >
-                            ✗
-                          </button>
-                        </div>
+                        <app-nack-overlay
+                          [messageId]="msg.id"
+                          (nackConfirmed)="onNackConfirm($event)"
+                          (nackCancelled)="nackOpenId.set(null)"
+                        />
                       } @else {
                         <button
-                          (click)="$event.stopPropagation(); nackOpenId.set(msg.id); nackError.set('')"
+                          (click)="$event.stopPropagation(); nackOpenId.set(msg.id)"
                           [attr.aria-label]="'Nack message ' + msg.id"
                           class="px-2 py-0.5 text-xs font-medium bg-red-100 text-red-800 rounded hover:bg-red-200 cursor-pointer whitespace-nowrap"
                         >
@@ -381,7 +341,6 @@ export class MessagesTable {
   readonly scrollbarWidth = signal(0);
 
   readonly nackOpenId = signal<string | null>(null);
-  readonly nackError = signal('');
   readonly copiedId = signal<string | null>(null);
   readonly purgeStatuses = signal<string[]>(['pending', 'processing', 'expired']);
   readonly showPurgeConfirm = signal(false);
@@ -417,16 +376,10 @@ export class MessagesTable {
     return Object.entries(metadata).map(([k, v]) => `${k}=${v}`).join(', ');
   }
 
-  private readonly STATUS_CLASS_MAP: Record<string, string> = {
-    pending:    'bg-yellow-100 text-yellow-800',
-    processing: 'bg-blue-100 text-blue-800',
-    failed:     'bg-red-100 text-red-800',
-    expired:    'bg-orange-100 text-orange-800',
-  };
   private readonly STATUS_BASE = 'inline-flex px-2 py-0.5 text-xs font-medium rounded-full';
 
   statusClasses(status: string): string {
-    return `${this.STATUS_BASE} ${this.STATUS_CLASS_MAP[status] ?? 'bg-gray-100 text-gray-800'}`;
+    return `${this.STATUS_BASE} ${STATUS_CLASS_MAP[status] ?? DEFAULT_STATUS_CLASS}`;
   }
 
   isDlq(msg: QueueMessage): boolean {
@@ -452,14 +405,12 @@ export class MessagesTable {
     if (this.nackOpenId() === null) return;
     if (!(event.target as Element).closest('[data-nack-overlay]')) {
       this.nackOpenId.set(null);
-      this.nackError.set('');
     }
   }
 
-  onNackConfirm(id: string): void {
-    this.nackConfirm.emit({ id, error: this.nackError() });
+  onNackConfirm({ id, error }: { id: string; error: string }): void {
+    this.nackConfirm.emit({ id, error });
     this.nackOpenId.set(null);
-    this.nackError.set('');
   }
 
   copyId(id: string): void {
@@ -482,9 +433,8 @@ export class MessagesTable {
     );
   }
 
-  confirmPurge(): void {
-    const topic = this.filterForm().value() ?? '';
-    this.purge.emit({ topic, statuses: this.purgeStatuses() });
+  confirmPurge(event: { topic: string; statuses: string[] }): void {
+    this.purge.emit(event);
     this.showPurgeConfirm.set(false);
   }
 

--- a/admin-ui/src/app/messages/nack-overlay.spec.ts
+++ b/admin-ui/src/app/messages/nack-overlay.spec.ts
@@ -1,0 +1,122 @@
+import { TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { NackOverlay } from './nack-overlay';
+
+const MESSAGE_ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+
+const setup = async () => {
+  await TestBed.configureTestingModule({
+    imports: [NackOverlay],
+    providers: [provideZonelessChangeDetection()],
+  }).compileComponents();
+
+  const fixture = TestBed.createComponent(NackOverlay);
+  fixture.componentRef.setInput('messageId', MESSAGE_ID);
+  fixture.detectChanges();
+  await fixture.whenStable();
+
+  return { fixture, component: fixture.componentInstance };
+};
+
+describe('NackOverlay', () => {
+  describe('data-nack-overlay attribute', () => {
+    it('should be present on the root div', async () => {
+      const { fixture } = await setup();
+      const el: HTMLElement = fixture.nativeElement;
+      expect(el.querySelector('[data-nack-overlay]')).not.toBeNull();
+    });
+  });
+
+  describe('when the confirm button (✓) is clicked with an empty reason', () => {
+    it('should emit nackConfirmed with the messageId and an empty error string', async () => {
+      const { fixture } = await setup();
+      const el: HTMLElement = fixture.nativeElement;
+
+      const emitted: { id: string; error: string }[] = [];
+      fixture.componentInstance.nackConfirmed.subscribe((v: { id: string; error: string }) =>
+        emitted.push(v),
+      );
+
+      const confirmBtn = el.querySelector<HTMLButtonElement>('button[title="Confirm nack"]');
+      confirmBtn?.click();
+      await fixture.whenStable();
+
+      expect(emitted.length).toBe(1);
+      expect(emitted[0]).toEqual({ id: MESSAGE_ID, error: '' });
+    });
+  });
+
+  describe('when the confirm button is clicked after typing a reason', () => {
+    it('should emit nackConfirmed with the typed error string', async () => {
+      const { fixture } = await setup();
+      const el: HTMLElement = fixture.nativeElement;
+
+      const emitted: { id: string; error: string }[] = [];
+      fixture.componentInstance.nackConfirmed.subscribe((v: { id: string; error: string }) =>
+        emitted.push(v),
+      );
+
+      const input = el.querySelector<HTMLInputElement>('input[type="text"]')!;
+      input.value = 'downstream failure';
+      input.dispatchEvent(new Event('input'));
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const confirmBtn = el.querySelector<HTMLButtonElement>('button[title="Confirm nack"]');
+      confirmBtn?.click();
+      await fixture.whenStable();
+
+      expect(emitted.length).toBe(1);
+      expect(emitted[0]).toEqual({ id: MESSAGE_ID, error: 'downstream failure' });
+    });
+
+    it('should reset the input to empty after confirming', async () => {
+      const { fixture, component } = await setup();
+      const el: HTMLElement = fixture.nativeElement;
+
+      const input = el.querySelector<HTMLInputElement>('input[type="text"]')!;
+      input.value = 'downstream failure';
+      input.dispatchEvent(new Event('input'));
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      const confirmBtn = el.querySelector<HTMLButtonElement>('button[title="Confirm nack"]');
+      confirmBtn?.click();
+      await fixture.whenStable();
+
+      expect(component.nackError()).toBe('');
+    });
+  });
+
+  describe('when the cancel button (✗) is clicked', () => {
+    it('should emit nackCancelled', async () => {
+      const { fixture } = await setup();
+      const el: HTMLElement = fixture.nativeElement;
+
+      let cancelledCount = 0;
+      fixture.componentInstance.nackCancelled.subscribe(() => { cancelledCount++; });
+
+      const cancelBtn = el.querySelector<HTMLButtonElement>('button[title="Cancel"]');
+      cancelBtn?.click();
+      await fixture.whenStable();
+
+      expect(cancelledCount).toBe(1);
+    });
+
+    it('should NOT emit nackConfirmed', async () => {
+      const { fixture } = await setup();
+      const el: HTMLElement = fixture.nativeElement;
+
+      const confirmedEmissions: unknown[] = [];
+      fixture.componentInstance.nackConfirmed.subscribe((v: unknown) =>
+        confirmedEmissions.push(v),
+      );
+
+      const cancelBtn = el.querySelector<HTMLButtonElement>('button[title="Cancel"]');
+      cancelBtn?.click();
+      await fixture.whenStable();
+
+      expect(confirmedEmissions.length).toBe(0);
+    });
+  });
+});

--- a/admin-ui/src/app/messages/nack-overlay.spec.ts
+++ b/admin-ui/src/app/messages/nack-overlay.spec.ts
@@ -56,9 +56,10 @@ describe('NackOverlay', () => {
         emitted.push(v),
       );
 
-      const input = el.querySelector<HTMLInputElement>('input[type="text"]')!;
-      input.value = 'downstream failure';
-      input.dispatchEvent(new Event('input'));
+      const input = el.querySelector<HTMLInputElement>('input[type="text"]');
+      expect(input).not.toBeNull();
+      (input as HTMLInputElement).value = 'downstream failure';
+      (input as HTMLInputElement).dispatchEvent(new Event('input'));
       fixture.detectChanges();
       await fixture.whenStable();
 
@@ -74,9 +75,10 @@ describe('NackOverlay', () => {
       const { fixture, component } = await setup();
       const el: HTMLElement = fixture.nativeElement;
 
-      const input = el.querySelector<HTMLInputElement>('input[type="text"]')!;
-      input.value = 'downstream failure';
-      input.dispatchEvent(new Event('input'));
+      const input = el.querySelector<HTMLInputElement>('input[type="text"]');
+      expect(input).not.toBeNull();
+      (input as HTMLInputElement).value = 'downstream failure';
+      (input as HTMLInputElement).dispatchEvent(new Event('input'));
       fixture.detectChanges();
       await fixture.whenStable();
 

--- a/admin-ui/src/app/messages/nack-overlay.ts
+++ b/admin-ui/src/app/messages/nack-overlay.ts
@@ -1,0 +1,51 @@
+import { Component, input, output, signal, ChangeDetectionStrategy } from '@angular/core';
+
+@Component({
+  selector: 'app-nack-overlay',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div
+      data-nack-overlay
+      class="absolute right-0 top-1/2 -translate-y-1/2 flex items-center gap-1 bg-white border border-gray-200 rounded shadow-md px-2 py-1 z-20"
+    >
+      <input
+        type="text"
+        [value]="nackError()"
+        (input)="nackError.set(inputValue($event))"
+        placeholder="Reason…"
+        class="px-1 py-0.5 text-xs border border-gray-300 rounded focus:outline-none focus:ring-1 focus:ring-red-400 w-28"
+      />
+      <button
+        (click)="onConfirm()"
+        title="Confirm nack"
+        class="px-1.5 py-0.5 text-xs font-medium bg-red-100 text-red-800 rounded hover:bg-red-200 cursor-pointer whitespace-nowrap"
+      >
+        ✓
+      </button>
+      <button
+        (click)="nackCancelled.emit()"
+        title="Cancel"
+        class="px-1.5 py-0.5 text-xs text-gray-500 hover:text-gray-700 cursor-pointer"
+      >
+        ✗
+      </button>
+    </div>
+  `,
+})
+export class NackOverlay {
+  readonly messageId = input.required<string>();
+
+  readonly nackConfirmed = output<{ id: string; error: string }>();
+  readonly nackCancelled = output<void>();
+
+  readonly nackError = signal('');
+
+  inputValue(e: Event): string {
+    return (e.target as HTMLInputElement).value;
+  }
+
+  onConfirm(): void {
+    this.nackConfirmed.emit({ id: this.messageId(), error: this.nackError() });
+    this.nackError.set('');
+  }
+}

--- a/admin-ui/src/app/messages/purge-confirm-panel.spec.ts
+++ b/admin-ui/src/app/messages/purge-confirm-panel.spec.ts
@@ -1,0 +1,117 @@
+import { TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { PurgeConfirmPanel } from './purge-confirm-panel';
+
+const DEFAULT_TOPIC = 'orders';
+const DEFAULT_STATUSES = ['pending', 'processing', 'expired'];
+
+const setup = async (opts: { topic?: string; statuses?: string[] } = {}) => {
+  const { topic = DEFAULT_TOPIC, statuses = DEFAULT_STATUSES } = opts;
+
+  await TestBed.configureTestingModule({
+    imports: [PurgeConfirmPanel],
+    providers: [provideZonelessChangeDetection()],
+  }).compileComponents();
+
+  const fixture = TestBed.createComponent(PurgeConfirmPanel);
+  fixture.componentRef.setInput('topic', topic);
+  fixture.componentRef.setInput('statuses', statuses);
+  fixture.detectChanges();
+  await fixture.whenStable();
+
+  return { fixture, component: fixture.componentInstance };
+};
+
+describe('PurgeConfirmPanel', () => {
+  describe('when rendered with a topic', () => {
+    it('should render the topic name in the panel heading', async () => {
+      const { fixture } = await setup({ topic: 'orders' });
+      const el: HTMLElement = fixture.nativeElement;
+      expect(el.textContent).toContain('Purge messages from "orders"');
+    });
+  });
+
+  describe('when Confirm purge is clicked', () => {
+    it('should emit purgeConfirmed with the topic and statuses', async () => {
+      const { fixture } = await setup();
+      const el: HTMLElement = fixture.nativeElement;
+
+      const emitted: { topic: string; statuses: string[] }[] = [];
+      fixture.componentInstance.purgeConfirmed.subscribe(
+        (v: { topic: string; statuses: string[] }) => emitted.push(v),
+      );
+
+      const confirmBtn = Array.from(el.querySelectorAll('button')).find(
+        (b) => b.textContent?.trim() === 'Confirm purge',
+      ) as HTMLButtonElement;
+      confirmBtn.click();
+      await fixture.whenStable();
+
+      expect(emitted.length).toBe(1);
+      expect(emitted[0]).toEqual({ topic: DEFAULT_TOPIC, statuses: DEFAULT_STATUSES });
+    });
+  });
+
+  describe('when Cancel is clicked', () => {
+    it('should emit purgeCancelled', async () => {
+      const { fixture } = await setup();
+      const el: HTMLElement = fixture.nativeElement;
+
+      let cancelledCount = 0;
+      fixture.componentInstance.purgeCancelled.subscribe(() => { cancelledCount++; });
+
+      const cancelBtn = Array.from(el.querySelectorAll('button')).find(
+        (b) => b.textContent?.trim() === 'Cancel',
+      ) as HTMLButtonElement;
+      cancelBtn.click();
+      await fixture.whenStable();
+
+      expect(cancelledCount).toBe(1);
+    });
+  });
+
+  describe('when a status checkbox is toggled', () => {
+    it('should emit statusToggle with the status string', async () => {
+      const { fixture } = await setup();
+      const el: HTMLElement = fixture.nativeElement;
+
+      const emitted: string[] = [];
+      fixture.componentInstance.statusToggle.subscribe((v: string) => emitted.push(v));
+
+      const checkboxes = el.querySelectorAll<HTMLInputElement>('input[type="checkbox"]');
+      // Toggle the first checkbox (pending)
+      checkboxes[0].dispatchEvent(new Event('change'));
+      await fixture.whenStable();
+
+      expect(emitted.length).toBe(1);
+      expect(emitted[0]).toBe('pending');
+    });
+
+    it('should emit statusToggle with the correct status for each checkbox', async () => {
+      const { fixture } = await setup();
+      const el: HTMLElement = fixture.nativeElement;
+
+      const emitted: string[] = [];
+      fixture.componentInstance.statusToggle.subscribe((v: string) => emitted.push(v));
+
+      const checkboxes = el.querySelectorAll<HTMLInputElement>('input[type="checkbox"]');
+      checkboxes[1].dispatchEvent(new Event('change'));
+      await fixture.whenStable();
+
+      expect(emitted[0]).toBe('processing');
+    });
+  });
+
+  describe('when statuses input is empty', () => {
+    it('should disable the Confirm purge button', async () => {
+      const { fixture } = await setup({ statuses: [] });
+      const el: HTMLElement = fixture.nativeElement;
+
+      const confirmBtn = Array.from(el.querySelectorAll('button')).find(
+        (b) => b.textContent?.trim() === 'Confirm purge',
+      ) as HTMLButtonElement;
+
+      expect(confirmBtn.disabled).toBe(true);
+    });
+  });
+});

--- a/admin-ui/src/app/messages/purge-confirm-panel.ts
+++ b/admin-ui/src/app/messages/purge-confirm-panel.ts
@@ -1,0 +1,48 @@
+import { Component, input, output, ChangeDetectionStrategy } from '@angular/core';
+
+@Component({
+  selector: 'app-purge-confirm-panel',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div class="px-6 py-3 border-b border-red-200 bg-red-50 space-y-2">
+      <p class="text-sm font-medium text-red-800">Purge messages from "{{ topic() }}"</p>
+      <div class="flex gap-3 text-sm">
+        @for (status of ['pending', 'processing', 'expired']; track status) {
+          <label class="flex items-center gap-1 cursor-pointer">
+            <input
+              type="checkbox"
+              [checked]="statuses().includes(status)"
+              (change)="statusToggle.emit(status)"
+            />
+            {{ status }}
+          </label>
+        }
+      </div>
+      <div class="flex gap-2">
+        <button
+          type="button"
+          [disabled]="statuses().length === 0"
+          (click)="purgeConfirmed.emit({ topic: topic(), statuses: statuses() })"
+          class="px-3 py-1.5 text-sm font-medium text-white bg-red-600 rounded-md hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          Confirm purge
+        </button>
+        <button
+          type="button"
+          (click)="purgeCancelled.emit()"
+          class="px-3 py-1.5 text-sm font-medium text-gray-600 border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-gray-400 cursor-pointer"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  `,
+})
+export class PurgeConfirmPanel {
+  readonly topic = input.required<string>();
+  readonly statuses = input.required<string[]>();
+
+  readonly purgeConfirmed = output<{ topic: string; statuses: string[] }>();
+  readonly purgeCancelled = output<void>();
+  readonly statusToggle = output<string>();
+}

--- a/admin-ui/src/app/messages/status-classes.ts
+++ b/admin-ui/src/app/messages/status-classes.ts
@@ -2,7 +2,6 @@ export const STATUS_CLASS_MAP: Record<string, string> = {
   pending:    'bg-yellow-100 text-yellow-800',
   processing: 'bg-blue-100 text-blue-800',
   failed:     'bg-red-100 text-red-800',
-  completed:  'bg-green-100 text-green-800',
   expired:    'bg-orange-100 text-orange-800',
 };
 

--- a/admin-ui/src/app/messages/status-classes.ts
+++ b/admin-ui/src/app/messages/status-classes.ts
@@ -1,0 +1,9 @@
+export const STATUS_CLASS_MAP: Record<string, string> = {
+  pending:    'bg-yellow-100 text-yellow-800',
+  processing: 'bg-blue-100 text-blue-800',
+  failed:     'bg-red-100 text-red-800',
+  completed:  'bg-green-100 text-green-800',
+  expired:    'bg-orange-100 text-orange-800',
+};
+
+export const DEFAULT_STATUS_CLASS = 'bg-gray-100 text-gray-800';


### PR DESCRIPTION
## Summary
- Extract inline nack overlay into `NackOverlay` standalone component (owns `nackError` state)
- Extract purge confirm panel into `PurgeConfirmPanel` standalone component
- Move `STATUS_CLASS_MAP` to `status-classes.ts`
- Rename outputs `confirm`/`cancel` → `purgeConfirmed`/`purgeCancelled` to satisfy `@angular-eslint/no-output-native`
- Update `MessagesTable` to compose the new sub-components; `nackError` removed from parent

## Test plan
- [x] `npx nx test` — all messages-table specs pass
- [x] `npx nx lint` — no ESLint errors