### PR TITLE
feat: PG LISTEN/NOTIFY broadcaster for cross-instance cache invalidation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ queue-ti is designed for teams who want reliable, observable message processing 
 - [Development Workflow](#development-workflow)
 - [Project Structure](#project-structure)
 - [Deployment](#deployment)
+- [Internal Event Broadcasting](#internal-event-broadcasting)
 - [Release Management](#release-management)
 - [Troubleshooting](#troubleshooting)
 - [Contributing](#contributing)
@@ -455,6 +456,60 @@ In production with multiple backend replicas behind a load balancer:
 2. **Set Redis credentials** via `QUEUETI_REDIS_PASSWORD` and optionally `QUEUETI_REDIS_TLS_ENABLED`
 3. **Deploy replicas** — each instance connects to the same Redis and shares rate-limit state
 4. **Security note**: Bind your Redis instance to a private network or use authentication and TLS (`QUEUETI_REDIS_TLS_ENABLED=true`) in production
+
+## Internal Event Broadcasting
+
+queue-ti uses an internal event broadcast system to maintain cache coherence across multiple backend instances. When a topic schema or configuration is mutated via the HTTP API, a notification is published so all running instances can invalidate their in-memory caches, preventing stale data from being served.
+
+### Broadcast Channels
+
+| Channel | Trigger | Effect |
+|---------|---------|--------|
+| `queue_ti_schema_changed` | Topic Avro schema is created, updated, or deleted via `PUT /api/topic-schemas/:topic` or `DELETE /api/topic-schemas/:topic` | All instances delete the topic from `globalSchemaCache`, forcing the next enqueue to re-fetch from the database |
+| `queue_ti_config_changed` | Topic configuration is created, updated, or deleted via `PUT /api/topic-configs/:topic` or `DELETE /api/topic-configs/:topic` | Currently logged for observability; reserved for future in-memory config cache invalidation |
+
+### Implementation
+
+The broadcaster system is pluggable via the `Broadcaster` interface in `internal/broadcast/`:
+
+- **PostgreSQL implementation** (`broadcast.NewPG(pool)`) — Uses `LISTEN`/`NOTIFY` on a dedicated database connection. Messages are published with `pg_notify(channel, payload)` and subscribers receive them via a channel-based listener.
+- **Noop implementation** (`broadcast.Noop`) — Default, used for single-instance deployments. Satisfies the interface but publishes nothing.
+- **Future Redis implementation** — When Redis support is added, a Redis pub/sub implementation will replace the PostgreSQL broadcaster, maintaining the same `Broadcaster` interface.
+
+### Sequence Diagram
+
+```mermaid
+sequenceDiagram
+    participant A as Instance A
+    participant DB as PostgreSQL
+    participant B as Instance B
+    participant C as Instance C
+    
+    A->>DB: PATCH /api/topic-schemas/orders
+    activate DB
+    DB->>DB: Upsert Avro schema to topic_schemas table
+    DB-->>A: 200 OK
+    deactivate DB
+    
+    A->>A: Publish notification
+    A->>DB: SELECT pg_notify('queue_ti_schema_changed', 'orders')
+    DB->>B: Deliver notification
+    DB->>C: Deliver notification
+    
+    B->>B: Receive 'orders' on channel<br/>Delete orders from globalSchemaCache
+    C->>C: Receive 'orders' on channel<br/>Delete orders from globalSchemaCache
+```
+
+### Startup
+
+At server startup, the queue service registers the broadcaster and starts background listeners:
+
+```go
+broadcaster := broadcast.NewPG(pool)
+queueService.UseBroadcaster(ctx, broadcaster)
+```
+
+This call sets the broadcaster instance and immediately starts two background goroutines listening on `queue_ti_schema_changed` and `queue_ti_config_changed`. Listeners exit cleanly when `ctx` is cancelled (during graceful shutdown).
 
 ## Authentication & User Management
 

--- a/README.md
+++ b/README.md
@@ -485,7 +485,7 @@ sequenceDiagram
     participant B as Instance B
     participant C as Instance C
     
-    A->>DB: PATCH /api/topic-schemas/orders
+    A->>DB: PUT /api/topic-schemas/orders
     activate DB
     DB->>DB: Upsert Avro schema to topic_schemas table
     DB-->>A: 200 OK

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -103,8 +103,7 @@ func main() {
 	broadcaster := broadcast.NewPG(pool)
 
 	queueService := queue.NewService(pool, cfg.Queue.VisibilityTimeout, cfg.Queue.MaxRetries, cfg.Queue.MessageTTL, cfg.Queue.DLQThreshold, cfg.Queue.RequireTopicRegistration, rec)
-	queueService.SetBroadcaster(broadcaster)
-	queueService.StartBroadcastListener(ctx)
+	queueService.UseBroadcaster(ctx, broadcaster)
 	queueService.StartExpiryReaper(ctx, time.Minute)
 
 	reaperSchedule := cfg.Queue.DeleteReaperSchedule

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -101,6 +101,7 @@ func main() {
 	rec := metrics.New(pool, reg)
 
 	broadcaster := broadcast.NewPG(pool)
+	defer broadcaster.Close()
 
 	queueService := queue.NewService(pool, cfg.Queue.VisibilityTimeout, cfg.Queue.MaxRetries, cfg.Queue.MessageTTL, cfg.Queue.DLQThreshold, cfg.Queue.RequireTopicRegistration, rec)
 	queueService.UseBroadcaster(ctx, broadcaster)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -17,6 +17,7 @@ import (
 	"google.golang.org/grpc"
 
 	"github.com/Joessst-Dev/queue-ti/internal/auth"
+	"github.com/Joessst-Dev/queue-ti/internal/broadcast"
 	"github.com/Joessst-Dev/queue-ti/internal/config"
 	"github.com/Joessst-Dev/queue-ti/internal/db"
 	"github.com/Joessst-Dev/queue-ti/internal/metrics"
@@ -99,7 +100,11 @@ func main() {
 	reg := prometheus.NewRegistry()
 	rec := metrics.New(pool, reg)
 
+	broadcaster := broadcast.NewPG(pool)
+
 	queueService := queue.NewService(pool, cfg.Queue.VisibilityTimeout, cfg.Queue.MaxRetries, cfg.Queue.MessageTTL, cfg.Queue.DLQThreshold, cfg.Queue.RequireTopicRegistration, rec)
+	queueService.SetBroadcaster(broadcaster)
+	queueService.StartBroadcastListener(ctx)
 	queueService.StartExpiryReaper(ctx, time.Minute)
 
 	reaperSchedule := cfg.Queue.DeleteReaperSchedule

--- a/internal/broadcast/broadcaster.go
+++ b/internal/broadcast/broadcaster.go
@@ -1,0 +1,21 @@
+package broadcast
+
+import "context"
+
+// Broadcaster publishes and receives text notifications across service instances.
+// The PostgreSQL implementation uses LISTEN/NOTIFY; a future Redis implementation
+// will satisfy the same interface, making PG the fallback when Redis is disabled.
+type Broadcaster interface {
+	// Publish sends payload on channel to all subscribers across all instances.
+	Publish(ctx context.Context, channel, payload string) error
+	// Subscribe registers interest in channel. The returned channel receives
+	// payloads until cancel is called. The channel is closed after cancel.
+	Subscribe(ctx context.Context, channel string) (<-chan string, context.CancelFunc)
+	// Close releases any persistent resources held by the implementation.
+	Close() error
+}
+
+const (
+	ChannelSchemaChanged = "queue_ti_schema_changed"
+	ChannelConfigChanged = "queue_ti_config_changed"
+)

--- a/internal/broadcast/noop.go
+++ b/internal/broadcast/noop.go
@@ -8,11 +8,11 @@ func (Noop) Publish(_ context.Context, _, _ string) error {
 	return nil
 }
 
-func (Noop) Subscribe(_ context.Context, _ string) (<-chan string, context.CancelFunc) {
+func (Noop) Subscribe(ctx context.Context, _ string) (<-chan string, context.CancelFunc) {
 	ch := make(chan string)
-	ctx, cancel := context.WithCancel(context.Background())
+	subCtx, cancel := context.WithCancel(ctx)
 	go func() {
-		<-ctx.Done()
+		<-subCtx.Done()
 		close(ch)
 	}()
 	return ch, cancel

--- a/internal/broadcast/noop.go
+++ b/internal/broadcast/noop.go
@@ -1,0 +1,23 @@
+package broadcast
+
+import "context"
+
+type Noop struct{}
+
+func (Noop) Publish(_ context.Context, _, _ string) error {
+	return nil
+}
+
+func (Noop) Subscribe(_ context.Context, _ string) (<-chan string, context.CancelFunc) {
+	ch := make(chan string)
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		<-ctx.Done()
+		close(ch)
+	}()
+	return ch, cancel
+}
+
+func (Noop) Close() error {
+	return nil
+}

--- a/internal/broadcast/pg.go
+++ b/internal/broadcast/pg.go
@@ -1,0 +1,68 @@
+package broadcast
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type PG struct {
+	pool *pgxpool.Pool
+}
+
+func NewPG(pool *pgxpool.Pool) *PG {
+	return &PG{pool: pool}
+}
+
+func (p *PG) Publish(ctx context.Context, channel, payload string) error {
+	_, err := p.pool.Exec(ctx, "SELECT pg_notify($1, $2)", channel, payload)
+	return err
+}
+
+func (p *PG) Subscribe(ctx context.Context, channel string) (<-chan string, context.CancelFunc) {
+	subCtx, cancel := context.WithCancel(ctx)
+	ch := make(chan string, 16)
+
+	go func() {
+		defer close(ch)
+
+		conn, err := p.pool.Acquire(subCtx)
+		if err != nil {
+			if subCtx.Err() == nil {
+				slog.Error("broadcast: failed to acquire connection", "channel", channel, "error", err)
+			}
+			return
+		}
+		defer conn.Release()
+
+		if _, err := conn.Exec(subCtx, fmt.Sprintf("LISTEN %s", channel)); err != nil {
+			if subCtx.Err() == nil {
+				slog.Error("broadcast: LISTEN failed", "channel", channel, "error", err)
+			}
+			return
+		}
+
+		for {
+			notification, err := conn.Conn().WaitForNotification(subCtx)
+			if err != nil {
+				if subCtx.Err() == nil {
+					slog.Error("broadcast: wait for notification failed", "channel", channel, "error", err)
+				}
+				return
+			}
+			select {
+			case ch <- notification.Payload:
+			case <-subCtx.Done():
+				return
+			}
+		}
+	}()
+
+	return ch, cancel
+}
+
+func (p *PG) Close() error {
+	return nil
+}

--- a/internal/broadcast/pg.go
+++ b/internal/broadcast/pg.go
@@ -2,9 +2,10 @@ package broadcast
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
+	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -24,36 +25,17 @@ func (p *PG) Publish(ctx context.Context, channel, payload string) error {
 func (p *PG) Subscribe(ctx context.Context, channel string) (<-chan string, context.CancelFunc) {
 	subCtx, cancel := context.WithCancel(ctx)
 	ch := make(chan string, 16)
+	safeChannel := pgx.Identifier{channel}.Sanitize()
 
 	go func() {
 		defer close(ch)
-
-		conn, err := p.pool.Acquire(subCtx)
-		if err != nil {
-			if subCtx.Err() == nil {
-				slog.Error("broadcast: failed to acquire connection", "channel", channel, "error", err)
-			}
-			return
-		}
-		defer conn.Release()
-
-		if _, err := conn.Exec(subCtx, fmt.Sprintf("LISTEN %s", channel)); err != nil {
-			if subCtx.Err() == nil {
-				slog.Error("broadcast: LISTEN failed", "channel", channel, "error", err)
-			}
-			return
-		}
-
-		for {
-			notification, err := conn.Conn().WaitForNotification(subCtx)
-			if err != nil {
-				if subCtx.Err() == nil {
-					slog.Error("broadcast: wait for notification failed", "channel", channel, "error", err)
-				}
+		for subCtx.Err() == nil {
+			p.runListenLoop(subCtx, safeChannel, ch)
+			if subCtx.Err() != nil {
 				return
 			}
 			select {
-			case ch <- notification.Payload:
+			case <-time.After(2 * time.Second):
 			case <-subCtx.Done():
 				return
 			}
@@ -61,6 +43,39 @@ func (p *PG) Subscribe(ctx context.Context, channel string) (<-chan string, cont
 	}()
 
 	return ch, cancel
+}
+
+func (p *PG) runListenLoop(ctx context.Context, safeChannel string, ch chan<- string) {
+	conn, err := p.pool.Acquire(ctx)
+	if err != nil {
+		if ctx.Err() == nil {
+			slog.Error("broadcast: failed to acquire connection", "channel", safeChannel, "error", err)
+		}
+		return
+	}
+	defer conn.Release()
+
+	if _, err := conn.Exec(ctx, "LISTEN "+safeChannel); err != nil {
+		if ctx.Err() == nil {
+			slog.Error("broadcast: LISTEN failed", "channel", safeChannel, "error", err)
+		}
+		return
+	}
+
+	for {
+		notification, err := conn.Conn().WaitForNotification(ctx)
+		if err != nil {
+			if ctx.Err() == nil {
+				slog.Error("broadcast: notification wait failed — will reconnect", "channel", safeChannel, "error", err)
+			}
+			return
+		}
+		select {
+		case ch <- notification.Payload:
+		case <-ctx.Done():
+			return
+		}
+	}
 }
 
 func (p *PG) Close() error {

--- a/internal/broadcast/pg_test.go
+++ b/internal/broadcast/pg_test.go
@@ -1,0 +1,174 @@
+package broadcast_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/testcontainers/testcontainers-go"
+	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+	"github.com/testcontainers/testcontainers-go/wait"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Joessst-Dev/queue-ti/internal/broadcast"
+)
+
+var (
+	suiteCtx     context.Context
+	pgContainer  *tcpostgres.PostgresContainer
+	containerDSN string
+)
+
+func TestMain(m *testing.M) {
+	suiteCtx = context.Background()
+
+	var err error
+	pgContainer, err = tcpostgres.Run(suiteCtx,
+		"postgres:16-alpine",
+		tcpostgres.WithDatabase("broadcast_test"),
+		tcpostgres.WithUsername("postgres"),
+		tcpostgres.WithPassword("postgres"),
+		testcontainers.WithWaitStrategy(
+			wait.ForLog("database system is ready to accept connections").
+				WithOccurrence(2).
+				WithStartupTimeout(60*time.Second),
+		),
+	)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to start postgres container: %v\n", err)
+		os.Exit(1)
+	}
+
+	host, err := pgContainer.Host(suiteCtx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to get container host: %v\n", err)
+		os.Exit(1)
+	}
+	mappedPort, err := pgContainer.MappedPort(suiteCtx, "5432/tcp")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to get container port: %v\n", err)
+		os.Exit(1)
+	}
+	containerDSN = fmt.Sprintf(
+		"postgres://postgres:postgres@%s:%d/broadcast_test?sslmode=disable",
+		host, mappedPort.Num(),
+	)
+
+	code := m.Run()
+
+	_ = pgContainer.Terminate(suiteCtx)
+	os.Exit(code)
+}
+
+func TestBroadcast(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Broadcast Suite")
+}
+
+var _ = BeforeSuite(func() {
+	Expect(containerDSN).NotTo(BeEmpty())
+})
+
+var _ = AfterSuite(func() {
+	// Container is terminated by TestMain.
+})
+
+var _ = Describe("PG broadcaster", func() {
+	var (
+		pool *pgxpool.Pool
+		pg   *broadcast.PG
+		ctx  context.Context
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+
+		var err error
+		pool, err = pgxpool.New(ctx, containerDSN)
+		Expect(err).NotTo(HaveOccurred())
+
+		pg = broadcast.NewPG(pool)
+	})
+
+	AfterEach(func() {
+		Expect(pg.Close()).To(Succeed())
+		pool.Close()
+	})
+
+	Describe("Publish then Subscribe", func() {
+		Context("when a payload is published to a channel", func() {
+			It("should be received by a subscriber on that channel", func() {
+				ch, cancel := pg.Subscribe(ctx, broadcast.ChannelSchemaChanged)
+				defer cancel()
+
+				// Give the subscriber goroutine time to execute LISTEN before publishing.
+				time.Sleep(50 * time.Millisecond)
+
+				Expect(pg.Publish(ctx, broadcast.ChannelSchemaChanged, "orders")).To(Succeed())
+
+				Eventually(ch, 3*time.Second).Should(Receive(Equal("orders")))
+			})
+		})
+	})
+
+	Describe("Subscribe receives multiple payloads", func() {
+		Context("when three payloads are published in sequence", func() {
+			It("should deliver all three in order", func() {
+				ch, cancel := pg.Subscribe(ctx, broadcast.ChannelSchemaChanged)
+				defer cancel()
+
+				time.Sleep(50 * time.Millisecond)
+
+				for _, topic := range []string{"alpha", "beta", "gamma"} {
+					Expect(pg.Publish(ctx, broadcast.ChannelSchemaChanged, topic)).To(Succeed())
+				}
+
+				Eventually(ch, 3*time.Second).Should(Receive(Equal("alpha")))
+				Eventually(ch, 3*time.Second).Should(Receive(Equal("beta")))
+				Eventually(ch, 3*time.Second).Should(Receive(Equal("gamma")))
+			})
+		})
+	})
+
+	Describe("Cancel stops the subscriber", func() {
+		Context("when cancel is called", func() {
+			It("should close the channel", func() {
+				ch, cancel := pg.Subscribe(ctx, broadcast.ChannelSchemaChanged)
+
+				cancel()
+
+				Eventually(ch, 3*time.Second).Should(BeClosed())
+			})
+		})
+	})
+})
+
+var _ = Describe("Noop broadcaster", func() {
+	var noop broadcast.Noop
+
+	Describe("Publish", func() {
+		Context("always", func() {
+			It("should return nil", func() {
+				err := noop.Publish(context.Background(), broadcast.ChannelSchemaChanged, "any")
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+	})
+
+	Describe("Subscribe", func() {
+		Context("when cancel is called", func() {
+			It("should close the returned channel", func() {
+				ch, cancel := noop.Subscribe(context.Background(), broadcast.ChannelSchemaChanged)
+
+				cancel()
+
+				Eventually(ch, 3*time.Second).Should(BeClosed())
+			})
+		})
+	})
+})

--- a/internal/queue/schema.go
+++ b/internal/queue/schema.go
@@ -5,12 +5,15 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"sync"
 	"time"
 
 	"github.com/hamba/avro/v2"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Joessst-Dev/queue-ti/internal/broadcast"
 )
 
 var (
@@ -117,6 +120,27 @@ func DeleteTopicSchema(ctx context.Context, pool *pgxpool.Pool, topic string) er
 	globalSchemaCache.m.Delete(topic)
 	if _, err := pool.Exec(ctx, `DELETE FROM topic_schemas WHERE topic = $1`, topic); err != nil {
 		return fmt.Errorf("delete topic schema: %w", err)
+	}
+	return nil
+}
+
+func (s *Service) UpsertTopicSchemaAndNotify(ctx context.Context, topic, schemaJSON string) (*TopicSchema, error) {
+	ts, err := UpsertTopicSchema(ctx, s.pool, topic, schemaJSON)
+	if err != nil {
+		return nil, err
+	}
+	if err := s.broadcaster.Publish(ctx, broadcast.ChannelSchemaChanged, topic); err != nil {
+		slog.Warn("broadcast schema change failed", "topic", topic, "error", err)
+	}
+	return ts, nil
+}
+
+func (s *Service) DeleteTopicSchemaAndNotify(ctx context.Context, topic string) error {
+	if err := DeleteTopicSchema(ctx, s.pool, topic); err != nil {
+		return err
+	}
+	if err := s.broadcaster.Publish(ctx, broadcast.ChannelSchemaChanged, topic); err != nil {
+		slog.Warn("broadcast schema delete failed", "topic", topic, "error", err)
 	}
 	return nil
 }

--- a/internal/queue/service.go
+++ b/internal/queue/service.go
@@ -1,11 +1,15 @@
 package queue
 
 import (
+	"context"
 	"errors"
+	"log/slog"
 	"sync"
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/Joessst-Dev/queue-ti/internal/broadcast"
 )
 
 var (
@@ -60,6 +64,7 @@ type Service struct {
 	dlqThreshold             int
 	requireTopicRegistration bool
 	recorder                 MetricsRecorder
+	broadcaster              broadcast.Broadcaster
 
 	deleteReaperMu   sync.Mutex
 	deleteReaperStop func()
@@ -84,5 +89,48 @@ func NewService(pool *pgxpool.Pool, visibilityTimeout time.Duration, maxRetries 
 		dlqThreshold:             dlqThreshold,
 		requireTopicRegistration: requireTopicRegistration,
 		recorder:                 recorder,
+		broadcaster:              broadcast.Noop{},
+	}
+}
+
+func (s *Service) SetBroadcaster(b broadcast.Broadcaster) {
+	s.broadcaster = b
+}
+
+func (s *Service) StartBroadcastListener(ctx context.Context) {
+	go s.listenSchemaChanges(ctx)
+	go s.listenConfigChanges(ctx)
+}
+
+func (s *Service) listenSchemaChanges(ctx context.Context) {
+	ch, cancel := s.broadcaster.Subscribe(ctx, broadcast.ChannelSchemaChanged)
+	defer cancel()
+	for {
+		select {
+		case topic, ok := <-ch:
+			if !ok {
+				return
+			}
+			globalSchemaCache.m.Delete(topic)
+			slog.Info("schema cache invalidated via broadcast", "topic", topic)
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (s *Service) listenConfigChanges(ctx context.Context) {
+	ch, cancel := s.broadcaster.Subscribe(ctx, broadcast.ChannelConfigChanged)
+	defer cancel()
+	for {
+		select {
+		case topic, ok := <-ch:
+			if !ok {
+				return
+			}
+			slog.Info("config change received via broadcast", "topic", topic)
+		case <-ctx.Done():
+			return
+		}
 	}
 }

--- a/internal/queue/service.go
+++ b/internal/queue/service.go
@@ -93,42 +93,29 @@ func NewService(pool *pgxpool.Pool, visibilityTimeout time.Duration, maxRetries 
 	}
 }
 
-func (s *Service) SetBroadcaster(b broadcast.Broadcaster) {
+// UseBroadcaster sets the broadcaster and immediately starts the channel
+// listeners in background goroutines. Call once at startup after NewService.
+func (s *Service) UseBroadcaster(ctx context.Context, b broadcast.Broadcaster) {
 	s.broadcaster = b
+	go s.listenChannel(ctx, broadcast.ChannelSchemaChanged, func(topic string) {
+		globalSchemaCache.m.Delete(topic)
+		slog.Info("schema cache invalidated via broadcast", "topic", topic)
+	})
+	go s.listenChannel(ctx, broadcast.ChannelConfigChanged, func(topic string) {
+		slog.Info("config change received via broadcast", "topic", topic)
+	})
 }
 
-func (s *Service) StartBroadcastListener(ctx context.Context) {
-	go s.listenSchemaChanges(ctx)
-	go s.listenConfigChanges(ctx)
-}
-
-func (s *Service) listenSchemaChanges(ctx context.Context) {
-	ch, cancel := s.broadcaster.Subscribe(ctx, broadcast.ChannelSchemaChanged)
+func (s *Service) listenChannel(ctx context.Context, channel string, handle func(string)) {
+	ch, cancel := s.broadcaster.Subscribe(ctx, channel)
 	defer cancel()
 	for {
 		select {
-		case topic, ok := <-ch:
+		case payload, ok := <-ch:
 			if !ok {
 				return
 			}
-			globalSchemaCache.m.Delete(topic)
-			slog.Info("schema cache invalidated via broadcast", "topic", topic)
-		case <-ctx.Done():
-			return
-		}
-	}
-}
-
-func (s *Service) listenConfigChanges(ctx context.Context) {
-	ch, cancel := s.broadcaster.Subscribe(ctx, broadcast.ChannelConfigChanged)
-	defer cancel()
-	for {
-		select {
-		case topic, ok := <-ch:
-			if !ok {
-				return
-			}
-			slog.Info("config change received via broadcast", "topic", topic)
+			handle(payload)
 		case <-ctx.Done():
 			return
 		}

--- a/internal/queue/topic_config.go
+++ b/internal/queue/topic_config.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/jackc/pgx/v5"
+
+	"github.com/Joessst-Dev/queue-ti/internal/broadcast"
 )
 
 // TopicConfig holds per-topic overrides. A nil pointer field means "use global default".
@@ -58,6 +61,9 @@ func (s *Service) UpsertTopicConfig(ctx context.Context, cfg TopicConfig) error 
 	if err != nil {
 		return fmt.Errorf("upsert topic config: %w", err)
 	}
+	if err := s.broadcaster.Publish(ctx, broadcast.ChannelConfigChanged, cfg.Topic); err != nil {
+		slog.Warn("broadcast config change failed", "topic", cfg.Topic, "error", err)
+	}
 	return nil
 }
 
@@ -71,6 +77,9 @@ func (s *Service) DeleteTopicConfig(ctx context.Context, topic string) error {
 	}
 	if _, err := s.pool.Exec(ctx, `DELETE FROM topic_throughput WHERE topic = $1`, topic); err != nil {
 		return fmt.Errorf("delete topic throughput: %w", err)
+	}
+	if err := s.broadcaster.Publish(ctx, broadcast.ChannelConfigChanged, topic); err != nil {
+		slog.Warn("broadcast config delete failed", "topic", topic, "error", err)
 	}
 	return nil
 }

--- a/internal/server/handlers_topic_schema.go
+++ b/internal/server/handlers_topic_schema.go
@@ -54,7 +54,7 @@ func (s *HTTPServer) upsertTopicSchema(c *fiber.Ctx) error {
 		return jsonError(c, fiber.StatusBadRequest, "invalid request body")
 	}
 
-	ts, err := queue.UpsertTopicSchema(c.Context(), s.queueService.Pool(), topic, req.SchemaJSON)
+	ts, err := s.queueService.UpsertTopicSchemaAndNotify(c.Context(), topic, req.SchemaJSON)
 	if err != nil {
 		if errors.Is(err, queue.ErrInvalidSchema) {
 			return jsonError(c, fiber.StatusBadRequest, err.Error())
@@ -67,7 +67,7 @@ func (s *HTTPServer) upsertTopicSchema(c *fiber.Ctx) error {
 
 func (s *HTTPServer) deleteTopicSchema(c *fiber.Ctx) error {
 	topic := c.Params("topic")
-	if err := queue.DeleteTopicSchema(c.Context(), s.queueService.Pool(), topic); err != nil {
+	if err := s.queueService.DeleteTopicSchemaAndNotify(c.Context(), topic); err != nil {
 		slog.Error("delete topic schema failed", "topic", topic, "error", err)
 		return jsonError(c, fiber.StatusInternalServerError, "internal server error")
 	}


### PR DESCRIPTION
## Summary
- Adds `internal/broadcast` package with a `Broadcaster` interface backed by PostgreSQL LISTEN/NOTIFY
- A future Redis implementation will satisfy the same interface; PG is the fallback when Redis is disabled
- `globalSchemaCache` is now invalidated on every instance when a schema is upserted or deleted via the HTTP API
- Topic config changes are broadcast on `queue_ti_config_changed` for future consumers (no in-memory cache to invalidate yet)
- `Service.StartBroadcastListener` subscribes at startup; defaults to `Noop` so single-instance deployments need no config change

## How it works
- **Publish**: `SELECT pg_notify($1, $2)` via the pool — no persistent connection needed
- **Subscribe**: acquires one connection from the pool per channel, calls `LISTEN` then loops on `WaitForNotification`; releases on context cancel or error
- **Schema invalidation**: `UpsertTopicSchemaAndNotify` / `DeleteTopicSchemaAndNotify` wrap the existing package-level functions and publish after a successful DB mutation; publish errors are logged as warnings and do not fail the mutation

## Test plan
- [x] `make test` passes (9 Ginkgo suites including new Broadcast Suite with 5 specs)
- [x] Broadcast Suite covers: publish→receive, multiple payloads, cancel closes channel, Noop no-ops