### PR TITLE
feat(release): publish @queue-ti/client to npm on release tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,8 +121,52 @@ jobs:
         run: npx nx lint
 
   # ─────────────────────────────────────────────────────────────────────────────
+  # Job 1c: Node.js client — build, test, lint (gates the release)
+  # Mirrors the node-client job in ci.yml exactly.
+  # ─────────────────────────────────────────────────────────────────────────────
+  node-client:
+    name: "Node.js client: Build, Test & Lint"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    permissions:
+      contents: read
+
+    defaults:
+      run:
+        working-directory: clients/node
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: "ui/.nvmrc"
+
+      - name: Cache npm packages
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/.npm
+          key: npm-node-client-${{ runner.os }}-${{ hashFiles('clients/node/package-lock.json') }}
+          restore-keys: npm-node-client-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Run tests
+        run: npm test
+
+      - name: Run ESLint
+        run: npm run lint
+
+  # ─────────────────────────────────────────────────────────────────────────────
   # Job 2: Build & push Docker image to GHCR
-  # Only runs after both CI jobs pass. Builds a multi-platform manifest
+  # Only runs after all three gate jobs pass. Builds a multi-platform manifest
   # (linux/amd64 + linux/arm64) and pushes three conditional tags:
   #   - exact tag  — always (e.g. v2026.05.0-preview.1)
   #   - preview    — rolling pointer, only for tags containing "-preview"
@@ -132,7 +176,7 @@ jobs:
     name: "Docker: Build & push multi-arch image"
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: [backend, frontend]
+    needs: [backend, frontend, node-client]
 
     permissions:
       contents: read
@@ -185,7 +229,76 @@ jobs:
           cache-to: type=gha,mode=max
 
   # ─────────────────────────────────────────────────────────────────────────────
-  # Job 3: Create GitHub Release
+  # Job 3: Publish @queue-ti/client to npm
+  # Runs in parallel with publish-image after all gate jobs pass.
+  # Version is derived from the CalVer tag (v2026.05.1 → 2026.5.1).
+  # Pre-release tags (-preview, -rc) are published under the "next" dist-tag
+  # so they don't overwrite the "latest" pointer on npm.
+  # Requires NPM_TOKEN repository secret with publish access to @queue-ti/client.
+  # ─────────────────────────────────────────────────────────────────────────────
+  publish-npm:
+    name: "npm: Publish @queue-ti/client"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [backend, frontend, node-client]
+
+    permissions:
+      contents: read
+      id-token: write  # required for npm provenance attestation
+
+    defaults:
+      run:
+        working-directory: clients/node
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: "ui/.nvmrc"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Cache npm packages
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/.npm
+          key: npm-node-client-${{ runner.os }}-${{ hashFiles('clients/node/package-lock.json') }}
+          restore-keys: npm-node-client-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Set version from tag
+        # Strip the leading "v" from the CalVer tag so npm gets a plain semver
+        # (e.g. v2026.05.1 → 2026.5.1). --no-git-tag-version skips the git tag
+        # and commit that npm version would otherwise create on the runner.
+        run: |
+          VERSION="${{ github.ref_name }}"
+          npm version "${VERSION#v}" --no-git-tag-version
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish to npm
+        # Scoped packages require --access public to be listed publicly.
+        # Pre-releases are published under the "next" dist-tag so they don't
+        # replace the "latest" pointer on npm.
+        # --provenance attaches a signed build provenance to the package for
+        # supply chain transparency (requires id-token: write above).
+        run: |
+          TAG="${{ github.ref_name }}"
+          if [[ "$TAG" == *"-preview"* || "$TAG" == *"-rc"* ]]; then
+            npm publish --access public --tag next --provenance
+          else
+            npm publish --access public --provenance
+          fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # Job 4: Create GitHub Release
   # Runs after the image push succeeds. Uses the gh CLI (pre-installed on
   # ubuntu-latest) to create the release with auto-generated notes from merged
   # PRs. Pre-release flag is set automatically for -preview and -rc tags.
@@ -194,7 +307,7 @@ jobs:
     name: "GitHub: Create release"
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: [publish-image]
+    needs: [publish-image, publish-npm]
 
     permissions:
       contents: write

--- a/clients/node/package.json
+++ b/clients/node/package.json
@@ -4,6 +4,10 @@
   "description": "Node.js client for the queue-ti message queue service",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "README.md"
+  ],
   "scripts": {
     "build": "tsc -p tsconfig.build.json && cp ../../proto/queue.proto dist/queue.proto",
     "test": "vitest run",


### PR DESCRIPTION
## Summary

- Adds a `node-client` gate job to the release workflow (mirrors the CI job) — all three gates must pass before any publish step runs
- Adds a `publish-npm` job that derives the version from the CalVer tag, builds, and publishes `@queue-ti/client` to npm with provenance attestation
- Pre-release tags (`-preview`, `-rc`) are published under the `next` dist-tag to avoid clobbering `latest`
- `create-release` now waits for both `publish-image` and `publish-npm` to succeed
- Adds `"files": ["dist", "README.md"]` to `package.json` so only the built output is included in the published package

## Required setup

Add an `NPM_TOKEN` repository secret with publish rights to the `@queue-ti` scope on npmjs.com before cutting the first release.

## Release flow after this PR

```
push tag v2026.05.x
      │
      ├─ backend (gate)
      ├─ frontend (gate)       ← all three in parallel
      └─ node-client (gate)
              │
      ┌───────┴───────┐
  publish-image    publish-npm   ← in parallel
      └───────┬───────┘
        create-release
```