### PR TITLE
feat(grants): consumer group access control

### DIFF
--- a/README.md
+++ b/README.md
@@ -682,16 +682,53 @@ Regular users require explicit grants for each action and topic. A grant specifi
 
 **Grant semantics:**
 - `read` — Allows `GET /api/messages` and `GET /api/stats` for this topic
-- `write` — Allows `POST /api/messages`, `POST /api/messages/:id/ack`, `POST /api/messages/:id/nack`, `POST /api/messages/:id/requeue` for this topic; also required for gRPC `Dequeue` calls
+- `write` — Allows `POST /api/messages`, `POST /api/messages/:id/ack`, `POST /api/messages/:id/nack`, `POST /api/messages/:id/requeue` for this topic; also required for gRPC `Dequeue` calls. Note: `write` alone does not restrict which consumer groups are accessible.
 - `admin` — Allows topic configuration and schema management (`GET/PUT/DELETE /api/topic-configs/:topic`, `GET/PUT/DELETE /api/topic-schemas/:topic`) for this topic
+- `consume` — Restricts the user to a specific named consumer group on the topic. See **Consumer Group Grants** below.
 
 **Example grants:**
 
-| Username | Grant | Topic Pattern | Interpretation |
-|----------|-------|---------------|-----------------|
-| `alice` | `write` | `orders` | Can enqueue, dequeue, ack, and nack messages only in the `orders` topic |
-| `bob` | `read` | `*` | Can list and inspect all messages across all topics, but cannot modify any |
-| `charlie` | `admin` | `payments.*` | Can manage configuration and schema for all topics matching `payments.*` (e.g., `payments`, `payments.dlq`, `payments.v1`) |
+| Username | Grant | Topic Pattern | Consumer Group | Interpretation |
+|----------|-------|---------------|----------------|-----------------|
+| `alice` | `write` | `orders` | — | Can enqueue, dequeue, ack, and nack messages in `orders` (no group restriction) |
+| `bob` | `read` | `*` | — | Can list and inspect all messages across all topics |
+| `charlie` | `admin` | `payments.*` | — | Can manage configuration for topics matching `payments.*` |
+| `diana` | `consume` | `orders.*` | `warehouse` | Can only dequeue/ack/nack in `orders.*` topics when using consumer group `warehouse` |
+
+### Consumer Group Grants
+
+Consumer group grants let you restrict a user to a specific named consumer group on a topic. This is useful when multiple teams consume from the same topic and you want to enforce that each team only processes its own group.
+
+**Semantics:**
+- A user with no `consume` grants for a topic can consume from any group (unrestricted).
+- Once any `consume` grant exists for a user+topic, that user is restricted to only the explicitly granted groups.
+- A user can hold multiple `consume` grants for the same topic with different groups to allow access to more than one.
+- A `write` grant alone does not restrict groups. If a user has both `write` and `consume` grants for a topic, the `consume` grant restrictions apply.
+
+**Creating a consumer group grant via REST:**
+
+```bash
+curl -X POST -H "Authorization: Bearer <admin-token>" \
+  -H "Content-Type: application/json" \
+  -d '{"topic_pattern": "orders.*", "consumer_group": "warehouse"}' \
+  http://localhost:8080/api/users/550e8400-e29b-41d4-a716-446655440000/consumer-group-grants
+```
+
+Omitting `topic_pattern` defaults to `"*"` (all topics).
+
+**Response:** HTTP 201 Created
+```json
+{
+  "id": "...",
+  "user_id": "...",
+  "action": "consume",
+  "topic_pattern": "orders.*",
+  "consumer_group": "warehouse",
+  "created_at": "2025-01-15T12:00:00Z"
+}
+```
+
+Consumer group grants can be deleted via the existing `DELETE /api/users/:id/grants/:grant_id` endpoint.
 
 ### JWT Token Details
 
@@ -841,6 +878,14 @@ curl -H "Authorization: Bearer <token>" \
       "action": "write",
       "topic_pattern": "orders",
       "created_at": "2025-04-25T12:00:00Z"
+    },
+    {
+      "id": "991e8400...",
+      "user_id": "550e8400...",
+      "action": "consume",
+      "topic_pattern": "orders.*",
+      "consumer_group": "warehouse",
+      "created_at": "2025-04-25T12:01:00Z"
     }
   ]
 }
@@ -869,6 +914,26 @@ curl -X DELETE -H "Authorization: Bearer <token>" \
 ```
 
 **Response:** HTTP 204 No Content
+
+#### POST /api/users/:id/consumer-group-grants
+
+Creates a `consume` grant that restricts the user to a specific consumer group on a topic. Requires admin.
+
+```bash
+curl -X POST -H "Authorization: Bearer <admin-token>" \
+  -H "Content-Type: application/json" \
+  -d '{"topic_pattern": "orders.*", "consumer_group": "warehouse"}' \
+  http://localhost:8080/api/users/550e8400-e29b-41d4-a716-446655440000/consumer-group-grants
+```
+
+| Field | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `consumer_group` | Yes | — | The consumer group the user is restricted to |
+| `topic_pattern` | No | `*` | Topic pattern (`*`, `prefix.*`, or exact name) |
+
+**Response:** HTTP 201 Created — returns the created grant object with `action: "consume"`.
+
+Returns 400 if `consumer_group` is missing, 409 if the same user+topic+group combination already exists.
 
 ### Using JWT Tokens in HTTP Requests
 

--- a/backend/internal/db/migrations/014_add_consumer_group_grants.down.sql
+++ b/backend/internal/db/migrations/014_add_consumer_group_grants.down.sql
@@ -1,0 +1,8 @@
+DROP INDEX IF EXISTS uq_user_grants_consume;
+
+ALTER TABLE user_grants DROP COLUMN IF EXISTS consumer_group;
+
+ALTER TABLE user_grants
+    DROP CONSTRAINT user_grants_action_check,
+    ADD  CONSTRAINT user_grants_action_check
+         CHECK (action IN ('read', 'write', 'admin'));

--- a/backend/internal/db/migrations/014_add_consumer_group_grants.up.sql
+++ b/backend/internal/db/migrations/014_add_consumer_group_grants.up.sql
@@ -1,0 +1,11 @@
+ALTER TABLE user_grants
+    DROP CONSTRAINT IF EXISTS user_grants_action_check,
+    ADD  CONSTRAINT user_grants_action_check
+         CHECK (action IN ('read', 'write', 'admin', 'consume'));
+
+ALTER TABLE user_grants
+    ADD COLUMN IF NOT EXISTS consumer_group TEXT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_user_grants_consume
+    ON user_grants (user_id, topic_pattern, consumer_group)
+    WHERE action = 'consume';

--- a/backend/internal/server/grpc.go
+++ b/backend/internal/server/grpc.go
@@ -64,6 +64,34 @@ func (s *GRPCServer) checkGrant(ctx context.Context, action, topic string) error
 	return nil
 }
 
+// checkDequeueGrant verifies the caller has dequeue access (write or consume)
+// on the topic, and — when consumerGroup is non-empty — that the caller is
+// authorised for that specific consumer group. Grants are fetched once for
+// both checks to avoid a second round-trip.
+func (s *GRPCServer) checkDequeueGrant(ctx context.Context, topic, consumerGroup string) error {
+	if s.userStore == nil {
+		return nil
+	}
+	claims := auth.ClaimsFromContext(ctx)
+	if claims == nil {
+		return nil
+	}
+	if claims.IsAdmin {
+		return nil
+	}
+	grants, err := s.userStore.GetUserGrants(ctx, claims.UserID)
+	if err != nil {
+		return status.Errorf(codes.Internal, "failed to check grants: %v", err)
+	}
+	if !users.HasDequeueAccess(grants, topic) {
+		return status.Errorf(codes.PermissionDenied, "insufficient permissions")
+	}
+	if consumerGroup != "" && !users.HasConsumerGroupAccess(grants, topic, consumerGroup) {
+		return status.Errorf(codes.PermissionDenied, "insufficient permissions for consumer group")
+	}
+	return nil
+}
+
 func (s *GRPCServer) Enqueue(ctx context.Context, req *pb.EnqueueRequest) (*pb.EnqueueResponse, error) {
 	if req.Topic == "" {
 		return nil, status.Error(codes.InvalidArgument, "topic is required")
@@ -102,7 +130,7 @@ func (s *GRPCServer) Dequeue(ctx context.Context, req *pb.DequeueRequest) (*pb.D
 		return nil, err
 	}
 
-	if err := s.checkGrant(ctx, "write", req.Topic); err != nil {
+	if err := s.checkDequeueGrant(ctx, req.Topic, req.ConsumerGroup); err != nil {
 		return nil, err
 	}
 
@@ -147,7 +175,7 @@ func (s *GRPCServer) BatchDequeue(ctx context.Context, req *pb.BatchDequeueReque
 		return nil, err
 	}
 
-	if err := s.checkGrant(ctx, "write", req.Topic); err != nil {
+	if err := s.checkDequeueGrant(ctx, req.Topic, req.ConsumerGroup); err != nil {
 		return nil, err
 	}
 
@@ -196,7 +224,7 @@ func (s *GRPCServer) Ack(ctx context.Context, req *pb.AckRequest) (*pb.AckRespon
 		}
 		return nil, status.Errorf(codes.Internal, "failed to look up message: %v", err)
 	}
-	if err := s.checkGrant(ctx, "write", topic); err != nil {
+	if err := s.checkDequeueGrant(ctx, topic, req.ConsumerGroup); err != nil {
 		return nil, err
 	}
 
@@ -228,7 +256,7 @@ func (s *GRPCServer) Subscribe(req *pb.SubscribeRequest, stream pb.QueueService_
 		return err
 	}
 
-	if err := s.checkGrant(stream.Context(), "write", req.Topic); err != nil {
+	if err := s.checkDequeueGrant(stream.Context(), req.Topic, req.ConsumerGroup); err != nil {
 		return err
 	}
 
@@ -301,7 +329,7 @@ func (s *GRPCServer) Nack(ctx context.Context, req *pb.NackRequest) (*pb.NackRes
 		}
 		return nil, status.Errorf(codes.Internal, "failed to look up message: %v", err)
 	}
-	if err := s.checkGrant(ctx, "write", topic); err != nil {
+	if err := s.checkDequeueGrant(ctx, topic, req.ConsumerGroup); err != nil {
 		return nil, err
 	}
 

--- a/backend/internal/server/handlers_users.go
+++ b/backend/internal/server/handlers_users.go
@@ -19,11 +19,12 @@ type userResponse struct {
 }
 
 type grantResponse struct {
-	ID           string `json:"id"`
-	UserID       string `json:"user_id"`
-	Action       string `json:"action"`
-	TopicPattern string `json:"topic_pattern"`
-	CreatedAt    string `json:"created_at"`
+	ID            string `json:"id"`
+	UserID        string `json:"user_id"`
+	Action        string `json:"action"`
+	TopicPattern  string `json:"topic_pattern"`
+	ConsumerGroup string `json:"consumer_group,omitempty"`
+	CreatedAt     string `json:"created_at"`
 }
 
 type createUserRequest struct {
@@ -43,6 +44,11 @@ type addGrantRequest struct {
 	TopicPattern string `json:"topic_pattern"`
 }
 
+type addConsumerGroupGrantRequest struct {
+	TopicPattern  string `json:"topic_pattern"`
+	ConsumerGroup string `json:"consumer_group"`
+}
+
 func toUserResponse(u *users.User) userResponse {
 	return userResponse{
 		ID:        u.ID,
@@ -55,11 +61,12 @@ func toUserResponse(u *users.User) userResponse {
 
 func toGrantResponse(g *users.Grant) grantResponse {
 	return grantResponse{
-		ID:           g.ID,
-		UserID:       g.UserID,
-		Action:       g.Action,
-		TopicPattern: g.TopicPattern,
-		CreatedAt:    g.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
+		ID:            g.ID,
+		UserID:        g.UserID,
+		Action:        g.Action,
+		TopicPattern:  g.TopicPattern,
+		ConsumerGroup: g.ConsumerGroup,
+		CreatedAt:     g.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
 	}
 }
 
@@ -171,6 +178,30 @@ func (s *HTTPServer) addUserGrant(c *fiber.Ctx) error {
 	g, err := s.userStore.AddGrant(c.Context(), userID, req.Action, topicPattern)
 	if err != nil {
 		slog.Error("add user grant failed", "user_id", userID, "error", err)
+		return jsonError(c, fiber.StatusInternalServerError, "internal server error")
+	}
+	return c.Status(fiber.StatusCreated).JSON(toGrantResponse(g))
+}
+
+func (s *HTTPServer) addConsumerGroupGrant(c *fiber.Ctx) error {
+	userID := c.Params("id")
+	var req addConsumerGroupGrantRequest
+	if err := c.BodyParser(&req); err != nil {
+		return jsonError(c, fiber.StatusBadRequest, "invalid request body")
+	}
+	if req.ConsumerGroup == "" {
+		return jsonError(c, fiber.StatusBadRequest, "consumer_group is required")
+	}
+	topicPattern := req.TopicPattern
+	if topicPattern == "" {
+		topicPattern = "*"
+	}
+	g, err := s.userStore.AddConsumerGroupGrant(c.Context(), userID, topicPattern, req.ConsumerGroup)
+	if errors.Is(err, users.ErrDuplicate) {
+		return jsonError(c, fiber.StatusConflict, err.Error())
+	}
+	if err != nil {
+		slog.Error("add consumer group grant failed", "user_id", userID, "error", err)
 		return jsonError(c, fiber.StatusInternalServerError, "internal server error")
 	}
 	return c.Status(fiber.StatusCreated).JSON(toGrantResponse(g))

--- a/backend/internal/server/http.go
+++ b/backend/internal/server/http.go
@@ -125,6 +125,7 @@ func NewHTTPServer(qs *queue.Service, serverCfg config.ServerConfig, rateLimitSt
 	userRoutes.Get("/:id/grants", s.listUserGrants)
 	userRoutes.Post("/:id/grants", s.addUserGrant)
 	userRoutes.Delete("/:id/grants/:grantId", s.deleteUserGrant)
+	userRoutes.Post("/:id/consumer-group-grants", s.addConsumerGroupGrant)
 
 	api.Get("/messages", jwtAuth, s.requireGrant("read", func(c *fiber.Ctx) string { return c.Query("topic") }), s.listMessages)
 	api.Post("/messages", jwtAuth, s.requireGrant("write", func(c *fiber.Ctx) string {
@@ -134,14 +135,23 @@ func NewHTTPServer(qs *queue.Service, serverCfg config.ServerConfig, rateLimitSt
 		_ = json.Unmarshal(c.Body(), &peek)
 		return peek.Topic
 	}), s.enqueueMessage)
-	api.Post("/messages/dequeue", jwtAuth, s.requireGrant("write", func(c *fiber.Ctx) string {
-		var peek struct {
-			Topic string `json:"topic"`
-		}
-		_ = json.Unmarshal(c.Body(), &peek)
-		return peek.Topic
-	}), s.batchDequeueMessages)
-	api.Post("/messages/:id/nack", jwtAuth, s.requireWriteOnMsgTopic(), s.nackMessage)
+	api.Post("/messages/dequeue", jwtAuth, s.requireDequeueGrant(
+		func(c *fiber.Ctx) string {
+			var peek struct {
+				Topic string `json:"topic"`
+			}
+			_ = json.Unmarshal(c.Body(), &peek)
+			return peek.Topic
+		},
+		func(c *fiber.Ctx) string {
+			var peek struct {
+				ConsumerGroup string `json:"consumer_group"`
+			}
+			_ = json.Unmarshal(c.Body(), &peek)
+			return peek.ConsumerGroup
+		},
+	), s.batchDequeueMessages)
+	api.Post("/messages/:id/nack", jwtAuth, s.requireDequeueOnMsgTopic(), s.nackMessage)
 	api.Post("/messages/:id/requeue", jwtAuth, s.requireWriteOnMsgTopic(), s.requeueMessage)
 	api.Get("/stats", jwtAuth, s.requireAdmin(), s.statsHandler)
 	api.Get("/topic-configs", jwtAuth, s.requireAdmin(), s.listTopicConfigs)

--- a/backend/internal/server/http.go
+++ b/backend/internal/server/http.go
@@ -136,22 +136,17 @@ func NewHTTPServer(qs *queue.Service, serverCfg config.ServerConfig, rateLimitSt
 		return peek.Topic
 	}), s.enqueueMessage)
 	api.Post("/messages/dequeue", jwtAuth, s.requireDequeueGrant(
-		func(c *fiber.Ctx) string {
+		func(c *fiber.Ctx) (string, string) {
 			var peek struct {
-				Topic string `json:"topic"`
-			}
-			_ = json.Unmarshal(c.Body(), &peek)
-			return peek.Topic
-		},
-		func(c *fiber.Ctx) string {
-			var peek struct {
+				Topic         string `json:"topic"`
 				ConsumerGroup string `json:"consumer_group"`
 			}
 			_ = json.Unmarshal(c.Body(), &peek)
-			return peek.ConsumerGroup
+			return peek.Topic, peek.ConsumerGroup
 		},
 	), s.batchDequeueMessages)
 	api.Post("/messages/:id/nack", jwtAuth, s.requireDequeueOnMsgTopic(), s.nackMessage)
+	// requeue intentionally requires "write"; a consume-only user may not requeue.
 	api.Post("/messages/:id/requeue", jwtAuth, s.requireWriteOnMsgTopic(), s.requeueMessage)
 	api.Get("/stats", jwtAuth, s.requireAdmin(), s.statsHandler)
 	api.Get("/topic-configs", jwtAuth, s.requireAdmin(), s.listTopicConfigs)

--- a/backend/internal/server/http_test.go
+++ b/backend/internal/server/http_test.go
@@ -2001,6 +2001,85 @@ var _ = Describe("HTTP Server", func() {
 	})
 
 	// ---------------------------------------------------------------------------
+	// POST /api/messages/dequeue — consume grant enforcement
+	// ---------------------------------------------------------------------------
+
+	Describe("POST /api/messages/dequeue consumer-group grant enforcement", func() {
+		var (
+			httpServer *server.HTTPServer
+			consumer   *users.User
+		)
+
+		BeforeEach(func() {
+			httpServer = server.NewHTTPServer(queueService, config.ServerConfig{CORSOrigins: "*"}, nil, config.AuthConfig{
+				Enabled:   true,
+				JWTSecret: testJWTSecret,
+			}, prometheus.NewRegistry(), userStore, "dev")
+
+			var err error
+			consumer, err = userStore.Create(httpTestCtx, "cg-dequeue-consumer", "strongpassword123", false)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = queueService.Enqueue(httpTestCtx, "cg-dequeue-t", []byte(`{"x":1}`), nil, nil)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		Context("when user has a consume grant for the topic and uses the correct group", func() {
+			It("should return 200", func() {
+				_, err := userStore.AddConsumerGroupGrant(httpTestCtx, consumer.ID, "cg-dequeue-t", "grp-a")
+				Expect(err).NotTo(HaveOccurred())
+				token, err := users.IssueToken([]byte(testJWTSecret), consumer.ID, consumer.Username, consumer.IsAdmin)
+				Expect(err).NotTo(HaveOccurred())
+
+				body := `{"topic":"cg-dequeue-t","count":1,"consumer_group":"grp-a","visibility_timeout":30}`
+				req := httptest.NewRequest("POST", "/api/messages/dequeue", strings.NewReader(body))
+				req.Header.Set("Content-Type", "application/json")
+				req.Header.Set("Authorization", "Bearer "+token)
+				resp, err := httpServer.App.Test(req)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp.StatusCode).To(Equal(200))
+			})
+		})
+
+		Context("when user has a consume grant but uses a different group", func() {
+			It("should return 403", func() {
+				_, err := userStore.AddConsumerGroupGrant(httpTestCtx, consumer.ID, "cg-dequeue-t", "grp-a")
+				Expect(err).NotTo(HaveOccurred())
+				token, err := users.IssueToken([]byte(testJWTSecret), consumer.ID, consumer.Username, consumer.IsAdmin)
+				Expect(err).NotTo(HaveOccurred())
+
+				body := `{"topic":"cg-dequeue-t","count":1,"consumer_group":"grp-wrong","visibility_timeout":30}`
+				req := httptest.NewRequest("POST", "/api/messages/dequeue", strings.NewReader(body))
+				req.Header.Set("Content-Type", "application/json")
+				req.Header.Set("Authorization", "Bearer "+token)
+				resp, err := httpServer.App.Test(req)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp.StatusCode).To(Equal(403))
+			})
+		})
+
+		Context("when user has only a write grant and sends no consumer_group", func() {
+			It("should return 200 (backward compat)", func() {
+				_, err := userStore.AddGrant(httpTestCtx, consumer.ID, "write", "cg-dequeue-t")
+				Expect(err).NotTo(HaveOccurred())
+				token, err := users.IssueToken([]byte(testJWTSecret), consumer.ID, consumer.Username, consumer.IsAdmin)
+				Expect(err).NotTo(HaveOccurred())
+
+				body := `{"topic":"cg-dequeue-t","count":1,"visibility_timeout":30}`
+				req := httptest.NewRequest("POST", "/api/messages/dequeue", strings.NewReader(body))
+				req.Header.Set("Content-Type", "application/json")
+				req.Header.Set("Authorization", "Bearer "+token)
+				resp, err := httpServer.App.Test(req)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp.StatusCode).To(Equal(200))
+			})
+		})
+	})
+
+	// ---------------------------------------------------------------------------
 	// Redis-backed rate limiter integration test
 	// ---------------------------------------------------------------------------
 

--- a/backend/internal/server/http_test.go
+++ b/backend/internal/server/http_test.go
@@ -1885,6 +1885,122 @@ var _ = Describe("HTTP Server", func() {
 	})
 
 	// ---------------------------------------------------------------------------
+	// POST /api/users/:id/consumer-group-grants
+	// ---------------------------------------------------------------------------
+
+	Describe("POST /api/users/:id/consumer-group-grants", func() {
+		var (
+			httpServer *server.HTTPServer
+			adminToken string
+			targetUser *users.User
+		)
+
+		BeforeEach(func() {
+			httpServer = server.NewHTTPServer(queueService, config.ServerConfig{CORSOrigins: "*"}, nil, config.AuthConfig{
+				Enabled:   true,
+				JWTSecret: testJWTSecret,
+			}, prometheus.NewRegistry(), userStore, "dev")
+
+			admin, err := userStore.Create(httpTestCtx, "cgg-admin", "strongpassword123", true)
+			Expect(err).NotTo(HaveOccurred())
+			adminToken, err = users.IssueToken([]byte(testJWTSecret), admin.ID, admin.Username, admin.IsAdmin)
+			Expect(err).NotTo(HaveOccurred())
+
+			targetUser, err = userStore.Create(httpTestCtx, "cgg-target", "strongpassword123", false)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		Context("when a valid consumer_group and topic_pattern are provided", func() {
+			It("should return 201 with a grant whose action is 'consume'", func() {
+				body := `{"topic_pattern":"orders.*","consumer_group":"team-a"}`
+				req := httptest.NewRequest("POST", "/api/users/"+targetUser.ID+"/consumer-group-grants", strings.NewReader(body))
+				req.Header.Set("Content-Type", "application/json")
+				req.Header.Set("Authorization", "Bearer "+adminToken)
+				resp, err := httpServer.App.Test(req)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp.StatusCode).To(Equal(201))
+
+				var result map[string]any
+				Expect(json.NewDecoder(resp.Body).Decode(&result)).To(Succeed())
+				Expect(result["action"]).To(Equal("consume"))
+				Expect(result["topic_pattern"]).To(Equal("orders.*"))
+				Expect(result["consumer_group"]).To(Equal("team-a"))
+				Expect(result["id"]).NotTo(BeEmpty())
+			})
+		})
+
+		Context("when topic_pattern is omitted", func() {
+			It("should default to '*' and return 201", func() {
+				body := `{"consumer_group":"team-b"}`
+				req := httptest.NewRequest("POST", "/api/users/"+targetUser.ID+"/consumer-group-grants", strings.NewReader(body))
+				req.Header.Set("Content-Type", "application/json")
+				req.Header.Set("Authorization", "Bearer "+adminToken)
+				resp, err := httpServer.App.Test(req)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp.StatusCode).To(Equal(201))
+
+				var result map[string]any
+				Expect(json.NewDecoder(resp.Body).Decode(&result)).To(Succeed())
+				Expect(result["topic_pattern"]).To(Equal("*"))
+			})
+		})
+
+		Context("when consumer_group is missing", func() {
+			It("should return 400", func() {
+				body := `{"topic_pattern":"orders.*"}`
+				req := httptest.NewRequest("POST", "/api/users/"+targetUser.ID+"/consumer-group-grants", strings.NewReader(body))
+				req.Header.Set("Content-Type", "application/json")
+				req.Header.Set("Authorization", "Bearer "+adminToken)
+				resp, err := httpServer.App.Test(req)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp.StatusCode).To(Equal(400))
+				Expect(decodeErrorBody(resp.Body)).To(Equal("consumer_group is required"))
+			})
+		})
+
+		Context("when the same grant is added twice", func() {
+			It("should return 409 on the second call", func() {
+				dupBody := `{"topic_pattern":"orders","consumer_group":"team-dup"}`
+
+				req1 := httptest.NewRequest("POST", "/api/users/"+targetUser.ID+"/consumer-group-grants", strings.NewReader(dupBody))
+				req1.Header.Set("Content-Type", "application/json")
+				req1.Header.Set("Authorization", "Bearer "+adminToken)
+				resp1, err := httpServer.App.Test(req1)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp1.StatusCode).To(Equal(201))
+
+				req2 := httptest.NewRequest("POST", "/api/users/"+targetUser.ID+"/consumer-group-grants", strings.NewReader(dupBody))
+				req2.Header.Set("Content-Type", "application/json")
+				req2.Header.Set("Authorization", "Bearer "+adminToken)
+				resp2, err := httpServer.App.Test(req2)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp2.StatusCode).To(Equal(409))
+			})
+		})
+
+		Context("when the caller is not an admin", func() {
+			It("should return 403", func() {
+				nonAdmin, err := userStore.Create(httpTestCtx, "cgg-nonadmin", "strongpassword123", false)
+				Expect(err).NotTo(HaveOccurred())
+				token, err := users.IssueToken([]byte(testJWTSecret), nonAdmin.ID, nonAdmin.Username, nonAdmin.IsAdmin)
+				Expect(err).NotTo(HaveOccurred())
+
+				body := `{"consumer_group":"group-x"}`
+				req := httptest.NewRequest("POST", "/api/users/"+targetUser.ID+"/consumer-group-grants", strings.NewReader(body))
+				req.Header.Set("Content-Type", "application/json")
+				req.Header.Set("Authorization", "Bearer "+token)
+				resp, err := httpServer.App.Test(req)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp.StatusCode).To(Equal(403))
+			})
+		})
+	})
+
+	// ---------------------------------------------------------------------------
 	// Redis-backed rate limiter integration test
 	// ---------------------------------------------------------------------------
 

--- a/backend/internal/server/middleware.go
+++ b/backend/internal/server/middleware.go
@@ -91,16 +91,15 @@ func (s *HTTPServer) requireWriteOnMsgTopic() fiber.Handler {
 }
 
 // requireDequeueGrant checks dequeue access (write or consume) on a topic,
-// and optionally consumer-group access when a group is present. topicFn and
-// groupFn are called with the current request context to extract these values.
-func (s *HTTPServer) requireDequeueGrant(topicFn, groupFn func(*fiber.Ctx) string) fiber.Handler {
+// and optionally consumer-group access when a group is present. extractFn is
+// called once to parse both values, avoiding redundant body unmarshalling.
+func (s *HTTPServer) requireDequeueGrant(extractFn func(*fiber.Ctx) (string, string)) fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		if done, err := s.checkAuthAndAdmin(c); done {
 			return err
 		}
 		claims := internalAuth.ClaimsFromCtx(c)
-		topic := topicFn(c)
-		group := groupFn(c)
+		topic, group := extractFn(c)
 		grants, err := s.userStore.GetUserGrants(c.Context(), claims.UserID)
 		if err != nil {
 			return jsonError(c, fiber.StatusInternalServerError, errMsgFailedCheckPerms)

--- a/backend/internal/server/middleware.go
+++ b/backend/internal/server/middleware.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"encoding/json"
+
 	"github.com/gofiber/fiber/v2"
 
 	internalAuth "github.com/Joessst-Dev/queue-ti/internal/auth"
@@ -82,6 +84,64 @@ func (s *HTTPServer) requireWriteOnMsgTopic() fiber.Handler {
 			return jsonError(c, fiber.StatusInternalServerError, errMsgFailedCheckPerms)
 		}
 		if !users.HasGrant(grants, "write", topic) {
+			return jsonError(c, fiber.StatusForbidden, errMsgInsufficientPerms)
+		}
+		return c.Next()
+	}
+}
+
+// requireDequeueGrant checks dequeue access (write or consume) on a topic,
+// and optionally consumer-group access when a group is present. topicFn and
+// groupFn are called with the current request context to extract these values.
+func (s *HTTPServer) requireDequeueGrant(topicFn, groupFn func(*fiber.Ctx) string) fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		if done, err := s.checkAuthAndAdmin(c); done {
+			return err
+		}
+		claims := internalAuth.ClaimsFromCtx(c)
+		topic := topicFn(c)
+		group := groupFn(c)
+		grants, err := s.userStore.GetUserGrants(c.Context(), claims.UserID)
+		if err != nil {
+			return jsonError(c, fiber.StatusInternalServerError, errMsgFailedCheckPerms)
+		}
+		if !users.HasDequeueAccess(grants, topic) {
+			return jsonError(c, fiber.StatusForbidden, errMsgInsufficientPerms)
+		}
+		if group != "" && !users.HasConsumerGroupAccess(grants, topic, group) {
+			return jsonError(c, fiber.StatusForbidden, errMsgInsufficientPerms)
+		}
+		return c.Next()
+	}
+}
+
+// requireDequeueOnMsgTopic is like requireWriteOnMsgTopic but checks dequeue
+// access (write or consume) and additionally validates consumer-group access
+// when "consumer_group" is present in the request body.
+func (s *HTTPServer) requireDequeueOnMsgTopic() fiber.Handler {
+	return func(c *fiber.Ctx) error {
+		if done, err := s.checkAuthAndAdmin(c); done {
+			return err
+		}
+		claims := internalAuth.ClaimsFromCtx(c)
+		id := c.Params("id")
+		topic, err := s.queueService.TopicForMessage(c.Context(), id)
+		if err != nil {
+			return jsonError(c, fiber.StatusNotFound, errMsgMessageNotFound)
+		}
+		grants, err := s.userStore.GetUserGrants(c.Context(), claims.UserID)
+		if err != nil {
+			return jsonError(c, fiber.StatusInternalServerError, errMsgFailedCheckPerms)
+		}
+		if !users.HasDequeueAccess(grants, topic) {
+			return jsonError(c, fiber.StatusForbidden, errMsgInsufficientPerms)
+		}
+		var peek struct {
+			ConsumerGroup string `json:"consumer_group"`
+		}
+		// c.Body() is idempotent in Fiber; the handler will re-parse safely.
+		_ = json.Unmarshal(c.Body(), &peek)
+		if peek.ConsumerGroup != "" && !users.HasConsumerGroupAccess(grants, topic, peek.ConsumerGroup) {
 			return jsonError(c, fiber.StatusForbidden, errMsgInsufficientPerms)
 		}
 		return c.Next()

--- a/backend/internal/users/permissions.go
+++ b/backend/internal/users/permissions.go
@@ -20,3 +20,30 @@ func HasGrant(grants []Grant, action, topic string) bool {
 	}
 	return false
 }
+
+// HasDequeueAccess returns true when the user holds a "write" or "consume"
+// grant that covers the given topic. Both actions permit consuming messages.
+func HasDequeueAccess(grants []Grant, topic string) bool {
+	return HasGrant(grants, "write", topic) || HasGrant(grants, "consume", topic)
+}
+
+// HasConsumerGroupAccess returns true when the user may consume from the given
+// consumer group on the given topic.
+//
+// The restriction is opt-in: if the user has no "consume" grants at all for the
+// topic, all groups are permitted. Once any "consume" grant exists for the topic
+// the user is restricted to explicitly granted groups only.
+func HasConsumerGroupAccess(grants []Grant, topic, consumerGroup string) bool {
+	var hasAnyConsumeForTopic bool
+	for _, g := range grants {
+		if g.Action != "consume" || !MatchesPattern(g.TopicPattern, topic) {
+			continue
+		}
+		hasAnyConsumeForTopic = true
+		if g.ConsumerGroup == consumerGroup {
+			return true
+		}
+	}
+	// No consume grants for this topic — restriction is not active.
+	return !hasAnyConsumeForTopic
+}

--- a/backend/internal/users/permissions.go
+++ b/backend/internal/users/permissions.go
@@ -44,6 +44,8 @@ func HasConsumerGroupAccess(grants []Grant, topic, consumerGroup string) bool {
 			return true
 		}
 	}
-	// No consume grants for this topic — restriction is not active.
+	// Note: a "write" grant does not bypass this check. Once any consume grant
+	// exists for this topic, only explicitly granted groups are accessible even
+	// if the caller also holds a "write" grant.
 	return !hasAnyConsumeForTopic
 }

--- a/backend/internal/users/permissions_test.go
+++ b/backend/internal/users/permissions_test.go
@@ -54,6 +54,115 @@ var _ = Describe("MatchesPattern", func() {
 	})
 })
 
+var _ = Describe("HasDequeueAccess", func() {
+	Context("when the grants list is empty", func() {
+		It("should return false", func() {
+			Expect(users.HasDequeueAccess(nil, "orders")).To(BeFalse())
+			Expect(users.HasDequeueAccess([]users.Grant{}, "orders")).To(BeFalse())
+		})
+	})
+
+	Context("when the user has a write grant on the topic", func() {
+		It("should return true", func() {
+			grants := []users.Grant{
+				{Action: "write", TopicPattern: "orders"},
+			}
+			Expect(users.HasDequeueAccess(grants, "orders")).To(BeTrue())
+		})
+	})
+
+	Context("when the user has a consume grant on the topic", func() {
+		It("should return true", func() {
+			grants := []users.Grant{
+				{Action: "consume", TopicPattern: "orders", ConsumerGroup: "group-a"},
+			}
+			Expect(users.HasDequeueAccess(grants, "orders")).To(BeTrue())
+		})
+	})
+
+	Context("when the user only has a read grant on the topic", func() {
+		It("should return false", func() {
+			grants := []users.Grant{
+				{Action: "read", TopicPattern: "orders"},
+			}
+			Expect(users.HasDequeueAccess(grants, "orders")).To(BeFalse())
+		})
+	})
+
+	Context("when the user has a write grant on a wildcard pattern", func() {
+		It("should return true for any matching topic", func() {
+			grants := []users.Grant{
+				{Action: "write", TopicPattern: "*"},
+			}
+			Expect(users.HasDequeueAccess(grants, "orders")).To(BeTrue())
+			Expect(users.HasDequeueAccess(grants, "payments")).To(BeTrue())
+		})
+	})
+
+	Context("when the user has write access to a different topic", func() {
+		It("should return false for the unmatched topic", func() {
+			grants := []users.Grant{
+				{Action: "write", TopicPattern: "payments"},
+			}
+			Expect(users.HasDequeueAccess(grants, "orders")).To(BeFalse())
+		})
+	})
+})
+
+var _ = Describe("HasConsumerGroupAccess", func() {
+	Context("when the user has no consume grants for the topic", func() {
+		It("should return true unconditionally (opt-in restriction)", func() {
+			Expect(users.HasConsumerGroupAccess(nil, "orders", "group-a")).To(BeTrue())
+			Expect(users.HasConsumerGroupAccess([]users.Grant{}, "orders", "group-a")).To(BeTrue())
+		})
+
+		It("should return true even when the user has non-consume grants on the topic", func() {
+			grants := []users.Grant{
+				{Action: "write", TopicPattern: "orders"},
+				{Action: "read", TopicPattern: "orders"},
+			}
+			Expect(users.HasConsumerGroupAccess(grants, "orders", "group-a")).To(BeTrue())
+		})
+
+		It("should return true when consume grants exist for a different topic only", func() {
+			grants := []users.Grant{
+				{Action: "consume", TopicPattern: "payments", ConsumerGroup: "group-a"},
+			}
+			Expect(users.HasConsumerGroupAccess(grants, "orders", "group-a")).To(BeTrue())
+		})
+	})
+
+	Context("when the user has at least one consume grant for the topic", func() {
+		It("should return true only for the explicitly granted group", func() {
+			grants := []users.Grant{
+				{Action: "consume", TopicPattern: "orders", ConsumerGroup: "group-a"},
+			}
+			Expect(users.HasConsumerGroupAccess(grants, "orders", "group-a")).To(BeTrue())
+			Expect(users.HasConsumerGroupAccess(grants, "orders", "group-b")).To(BeFalse())
+		})
+
+		It("should return true for any of multiple granted groups", func() {
+			grants := []users.Grant{
+				{Action: "consume", TopicPattern: "orders", ConsumerGroup: "group-a"},
+				{Action: "consume", TopicPattern: "orders", ConsumerGroup: "group-b"},
+			}
+			Expect(users.HasConsumerGroupAccess(grants, "orders", "group-a")).To(BeTrue())
+			Expect(users.HasConsumerGroupAccess(grants, "orders", "group-b")).To(BeTrue())
+			Expect(users.HasConsumerGroupAccess(grants, "orders", "group-c")).To(BeFalse())
+		})
+
+		It("should match consume grants using wildcard topic patterns", func() {
+			grants := []users.Grant{
+				{Action: "consume", TopicPattern: "orders.*", ConsumerGroup: "group-a"},
+			}
+			Expect(users.HasConsumerGroupAccess(grants, "orders.new", "group-a")).To(BeTrue())
+			Expect(users.HasConsumerGroupAccess(grants, "orders.new", "group-b")).To(BeFalse())
+			// A consume grant on orders.* does not activate restriction for payments
+			Expect(users.HasConsumerGroupAccess(grants, "payments", "group-a")).To(BeTrue())
+		})
+	})
+})
+
 var _ = Describe("HasGrant", func() {
 	Context("when the grants list is empty", func() {
 		It("should return false for any action and topic", func() {

--- a/backend/internal/users/users.go
+++ b/backend/internal/users/users.go
@@ -26,11 +26,12 @@ type User struct {
 }
 
 type Grant struct {
-	ID           string
-	UserID       string
-	Action       string
-	TopicPattern string
-	CreatedAt    time.Time
+	ID            string
+	UserID        string
+	Action        string
+	TopicPattern  string
+	ConsumerGroup string // non-empty only for action == "consume"
+	CreatedAt     time.Time
 }
 
 type Store struct {
@@ -170,15 +171,32 @@ func (s *Store) AddGrant(ctx context.Context, userID, action, topicPattern strin
 	err := s.pool.QueryRow(ctx,
 		`INSERT INTO user_grants (user_id, action, topic_pattern)
          VALUES ($1, $2, $3)
-         RETURNING id, user_id, action, topic_pattern, created_at`,
+         RETURNING id, user_id, action, topic_pattern, COALESCE(consumer_group, ''), created_at`,
 		userID, action, topicPattern,
-	).Scan(&g.ID, &g.UserID, &g.Action, &g.TopicPattern, &g.CreatedAt)
+	).Scan(&g.ID, &g.UserID, &g.Action, &g.TopicPattern, &g.ConsumerGroup, &g.CreatedAt)
 	return &g, err
+}
+
+func (s *Store) AddConsumerGroupGrant(ctx context.Context, userID, topicPattern, consumerGroup string) (*Grant, error) {
+	var g Grant
+	err := s.pool.QueryRow(ctx,
+		`INSERT INTO user_grants (user_id, action, topic_pattern, consumer_group)
+         VALUES ($1, 'consume', $2, $3)
+         RETURNING id, user_id, action, topic_pattern, COALESCE(consumer_group, ''), created_at`,
+		userID, topicPattern, consumerGroup,
+	).Scan(&g.ID, &g.UserID, &g.Action, &g.TopicPattern, &g.ConsumerGroup, &g.CreatedAt)
+	if err != nil {
+		if isUniqueViolation(err) {
+			return nil, ErrDuplicate
+		}
+		return nil, err
+	}
+	return &g, nil
 }
 
 func (s *Store) ListGrants(ctx context.Context, userID string) ([]Grant, error) {
 	rows, err := s.pool.Query(ctx,
-		`SELECT id, user_id, action, topic_pattern, created_at
+		`SELECT id, user_id, action, topic_pattern, COALESCE(consumer_group, ''), created_at
          FROM user_grants WHERE user_id = $1 ORDER BY created_at`,
 		userID,
 	)
@@ -189,7 +207,7 @@ func (s *Store) ListGrants(ctx context.Context, userID string) ([]Grant, error) 
 	var result []Grant
 	for rows.Next() {
 		var g Grant
-		if err := rows.Scan(&g.ID, &g.UserID, &g.Action, &g.TopicPattern, &g.CreatedAt); err != nil {
+		if err := rows.Scan(&g.ID, &g.UserID, &g.Action, &g.TopicPattern, &g.ConsumerGroup, &g.CreatedAt); err != nil {
 			return nil, err
 		}
 		result = append(result, g)

--- a/backend/internal/users/users_test.go
+++ b/backend/internal/users/users_test.go
@@ -353,6 +353,56 @@ var _ = Describe("Store", func() {
 			})
 		})
 
+		Describe("AddConsumerGroupGrant", func() {
+			Context("when adding a valid consume grant", func() {
+				It("should return a populated Grant with action 'consume' and the consumer group set", func() {
+					g, err := store.AddConsumerGroupGrant(usersTestCtx, owner.ID, "orders.*", "team-a")
+
+					Expect(err).NotTo(HaveOccurred())
+					Expect(g.ID).NotTo(BeEmpty())
+					Expect(g.UserID).To(Equal(owner.ID))
+					Expect(g.Action).To(Equal("consume"))
+					Expect(g.TopicPattern).To(Equal("orders.*"))
+					Expect(g.ConsumerGroup).To(Equal("team-a"))
+					Expect(g.CreatedAt).NotTo(BeZero())
+				})
+
+				It("should appear in ListGrants for that user", func() {
+					_, err := store.AddConsumerGroupGrant(usersTestCtx, owner.ID, "*", "team-b")
+					Expect(err).NotTo(HaveOccurred())
+
+					grants, err := store.ListGrants(usersTestCtx, owner.ID)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(grants).To(HaveLen(1))
+					Expect(grants[0].ConsumerGroup).To(Equal("team-b"))
+				})
+			})
+
+			Context("when the same user+topic_pattern+consumer_group combination is added twice", func() {
+				It("should return ErrDuplicate on the second call", func() {
+					_, err := store.AddConsumerGroupGrant(usersTestCtx, owner.ID, "orders", "team-a")
+					Expect(err).NotTo(HaveOccurred())
+
+					_, err = store.AddConsumerGroupGrant(usersTestCtx, owner.ID, "orders", "team-a")
+					Expect(err).To(MatchError(users.ErrDuplicate))
+				})
+			})
+
+			Context("when the same user+topic_pattern is used with a different consumer group", func() {
+				It("should succeed because the unique constraint is per group", func() {
+					_, err := store.AddConsumerGroupGrant(usersTestCtx, owner.ID, "orders", "team-a")
+					Expect(err).NotTo(HaveOccurred())
+
+					_, err = store.AddConsumerGroupGrant(usersTestCtx, owner.ID, "orders", "team-b")
+					Expect(err).NotTo(HaveOccurred())
+
+					grants, err := store.ListGrants(usersTestCtx, owner.ID)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(grants).To(HaveLen(2))
+				})
+			})
+		})
+
 		Describe("DeleteGrant", func() {
 			Context("when the grant exists for that user", func() {
 				It("should remove it so it no longer appears in ListGrants", func() {

--- a/ui/src/app/admin/users-section.spec.ts
+++ b/ui/src/app/admin/users-section.spec.ts
@@ -534,8 +534,8 @@ describe('UsersSection', () => {
       await fixture.whenStable();
       fixture.detectChanges();
 
-      component.newCgPattern.set('orders.*');
-      component.newCgGroup.set('workers');
+      component.newCgPattern.update((m) => ({ ...m, ['u1']: 'orders.*' }));
+      component.newCgGroup.update((m) => ({ ...m, ['u1']: 'workers' }));
       fixture.detectChanges();
 
       const addBtn = el.querySelector(`button[aria-label="Add consumer group grant for alice"]`) as HTMLButtonElement;
@@ -557,16 +557,16 @@ describe('UsersSection', () => {
       await fixture.whenStable();
       fixture.detectChanges();
 
-      component.newCgPattern.set('events.*');
-      component.newCgGroup.set('my-group');
+      component.newCgPattern.update((m) => ({ ...m, ['u1']: 'events.*' }));
+      component.newCgGroup.update((m) => ({ ...m, ['u1']: 'my-group' }));
 
       const addBtn = el.querySelector(`button[aria-label="Add consumer group grant for alice"]`) as HTMLButtonElement;
       addBtn.click();
       await fixture.whenStable();
       fixture.detectChanges();
 
-      expect(component.newCgPattern()).toBe('*');
-      expect(component.newCgGroup()).toBe('');
+      expect(component.cgPattern('u1')).toBe('*');
+      expect(component.cgGroup('u1')).toBe('');
     });
 
     it('should show an error banner when consumer group is empty', async () => {
@@ -578,7 +578,7 @@ describe('UsersSection', () => {
       await fixture.whenStable();
       fixture.detectChanges();
 
-      component.newCgGroup.set('');
+      component.newCgGroup.update((m) => ({ ...m, u1: '' }));
       fixture.detectChanges();
 
       const addBtn = el.querySelector(`button[aria-label="Add consumer group grant for alice"]`) as HTMLButtonElement;
@@ -603,7 +603,7 @@ describe('UsersSection', () => {
       await fixture.whenStable();
       fixture.detectChanges();
 
-      component.newCgGroup.set('workers');
+      component.newCgGroup.update((m) => ({ ...m, ['u1']: 'workers' }));
       fixture.detectChanges();
 
       const addBtn = el.querySelector(`button[aria-label="Add consumer group grant for alice"]`) as HTMLButtonElement;
@@ -613,6 +613,29 @@ describe('UsersSection', () => {
 
       expect(component.grantsError('u1')).toBe('Failed to add consumer group grant');
       expect(el.textContent).toContain('Failed to add consumer group grant');
+    });
+
+    it('should clear the grants error when the panel is closed', async () => {
+      const user = makeUser({ id: 'u1', username: 'alice' });
+      const { fixture, el, component } = await setup({ users: [user], listGrantsResult: [] });
+
+      const grantsBtn = el.querySelector(`button[aria-label="Toggle grants for alice"]`) as HTMLButtonElement;
+      grantsBtn.click();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      component.newCgGroup.update((m) => ({ ...m, u1: '' }));
+      fixture.detectChanges();
+      const addBtn = el.querySelector(`button[aria-label="Add consumer group grant for alice"]`) as HTMLButtonElement;
+      addBtn.click();
+      await fixture.whenStable();
+      fixture.detectChanges();
+      expect(component.grantsError('u1')).toBeTruthy();
+
+      grantsBtn.click();
+      await fixture.whenStable();
+      fixture.detectChanges();
+      expect(component.grantsError('u1')).toBe('');
     });
   });
 });

--- a/ui/src/app/admin/users-section.spec.ts
+++ b/ui/src/app/admin/users-section.spec.ts
@@ -480,10 +480,10 @@ describe('UsersSection', () => {
       await fixture.whenStable();
       fixture.detectChanges();
 
-      const rows = el.querySelectorAll('tbody tr');
-      // first data row (not the add-grant form row)
-      const firstRow = rows[0];
-      const cells = firstRow.querySelectorAll('td');
+      // Find the grant row via its delete button (proven to be reachable in other tests)
+      const deleteBtn = el.querySelector('[aria-label^="Delete grant"]') as HTMLElement;
+      const firstGrantRow = deleteBtn.closest('tr') as HTMLElement;
+      const cells = firstGrantRow.querySelectorAll('td');
       expect(cells[2].textContent?.trim()).toBe('—');
     });
 
@@ -505,8 +505,10 @@ describe('UsersSection', () => {
       await fixture.whenStable();
       fixture.detectChanges();
 
-      const firstRow = el.querySelectorAll('tbody tr')[0];
-      const cells = firstRow.querySelectorAll('td');
+      // Find the grant row via its delete button (proven to be reachable in other tests)
+      const deleteBtn = el.querySelector('[aria-label^="Delete grant"]') as HTMLElement;
+      const firstGrantRow = deleteBtn.closest('tr') as HTMLElement;
+      const cells = firstGrantRow.querySelectorAll('td');
       expect(cells[2].textContent?.trim()).toBe('my-group');
     });
   });

--- a/ui/src/app/admin/users-section.spec.ts
+++ b/ui/src/app/admin/users-section.spec.ts
@@ -31,6 +31,7 @@ const makeUserService = (opts: {
   listGrantsResult?: Grant[] | 'error';
   addGrantResult?: Grant | 'error';
   deleteGrantResult?: 'ok' | 'error';
+  addConsumerGroupGrantResult?: Grant | 'error';
 } = {}) => {
   const {
     listResult = [],
@@ -40,6 +41,7 @@ const makeUserService = (opts: {
     listGrantsResult = [],
     addGrantResult = makeGrant(),
     deleteGrantResult = 'ok',
+    addConsumerGroupGrantResult = makeGrant({ action: 'consume', consumer_group: 'default' }),
   } = opts;
 
   return {
@@ -78,6 +80,11 @@ const makeUserService = (opts: {
         ? throwError(() => ({ error: { error: 'Failed to delete grant' } }))
         : of(undefined),
     ),
+    addConsumerGroupGrant: vi.fn().mockReturnValue(
+      addConsumerGroupGrantResult === 'error'
+        ? throwError(() => ({ error: { error: 'Failed to add consumer group grant' } }))
+        : of(addConsumerGroupGrantResult as Grant),
+    ),
   } as unknown as UserService;
 };
 
@@ -90,6 +97,7 @@ const setup = async (opts: {
   listGrantsResult?: Grant[] | 'error';
   addGrantResult?: Grant | 'error';
   deleteGrantResult?: 'ok' | 'error';
+  addConsumerGroupGrantResult?: Grant | 'error';
 } = {}) => {
   const {
     users = [],
@@ -100,6 +108,7 @@ const setup = async (opts: {
     listGrantsResult,
     addGrantResult,
     deleteGrantResult,
+    addConsumerGroupGrantResult,
   } = opts;
 
   const userService = makeUserService({
@@ -110,6 +119,7 @@ const setup = async (opts: {
     listGrantsResult: listGrantsResult ?? [],
     addGrantResult: addGrantResult ?? makeGrant(),
     deleteGrantResult: deleteGrantResult ?? 'ok',
+    addConsumerGroupGrantResult: addConsumerGroupGrantResult ?? makeGrant({ action: 'consume', consumer_group: 'default' }),
   });
 
   await TestBed.configureTestingModule({
@@ -443,6 +453,164 @@ describe('UsersSection', () => {
       expect(userService.deleteGrant).toHaveBeenCalledWith('u1', 'g1');
       expect(component.grants()['u1']).toHaveLength(1);
       expect(component.grants()['u1'][0].id).toBe('g2');
+    });
+  });
+
+  describe('grants table Consumer Group column', () => {
+    it('should render the Consumer Group column header', async () => {
+      const user = makeUser({ id: 'u1', username: 'alice' });
+      const { fixture, el } = await setup({ users: [user] });
+
+      const grantsBtn = el.querySelector(`button[aria-label="Toggle grants for alice"]`) as HTMLButtonElement;
+      grantsBtn.click();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      const headers = Array.from(el.querySelectorAll('th')).map((th) => th.textContent?.trim());
+      expect(headers).toContain('Consumer Group');
+    });
+
+    it('should render — for grants without a consumer_group', async () => {
+      const user = makeUser({ id: 'u1', username: 'alice' });
+      const grants = [makeGrant({ id: 'g1', user_id: 'u1', action: 'read', topic_pattern: '*' })];
+      const { fixture, el } = await setup({ users: [user], listGrantsResult: grants });
+
+      const grantsBtn = el.querySelector(`button[aria-label="Toggle grants for alice"]`) as HTMLButtonElement;
+      grantsBtn.click();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      const rows = el.querySelectorAll('tbody tr');
+      // first data row (not the add-grant form row)
+      const firstRow = rows[0];
+      const cells = firstRow.querySelectorAll('td');
+      expect(cells[2].textContent?.trim()).toBe('—');
+    });
+
+    it('should render the consumer_group value for consume grants', async () => {
+      const user = makeUser({ id: 'u1', username: 'alice' });
+      const grants = [
+        makeGrant({
+          id: 'g1',
+          user_id: 'u1',
+          action: 'consume',
+          topic_pattern: 'orders.*',
+          consumer_group: 'my-group',
+        }),
+      ];
+      const { fixture, el } = await setup({ users: [user], listGrantsResult: grants });
+
+      const grantsBtn = el.querySelector(`button[aria-label="Toggle grants for alice"]`) as HTMLButtonElement;
+      grantsBtn.click();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      const firstRow = el.querySelectorAll('tbody tr')[0];
+      const cells = firstRow.querySelectorAll('td');
+      expect(cells[2].textContent?.trim()).toBe('my-group');
+    });
+  });
+
+  describe('when adding a consumer group grant', () => {
+    it('should call addConsumerGroupGrant() with the entered values', async () => {
+      const user = makeUser({ id: 'u1', username: 'alice' });
+      const newGrant = makeGrant({
+        id: 'g-cg',
+        user_id: 'u1',
+        action: 'consume',
+        topic_pattern: 'orders.*',
+        consumer_group: 'workers',
+      });
+      const { fixture, el, component, userService } = await setup({
+        users: [user],
+        listGrantsResult: [],
+        addConsumerGroupGrantResult: newGrant,
+      });
+
+      const grantsBtn = el.querySelector(`button[aria-label="Toggle grants for alice"]`) as HTMLButtonElement;
+      grantsBtn.click();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      component.newCgPattern.set('orders.*');
+      component.newCgGroup.set('workers');
+      fixture.detectChanges();
+
+      const addBtn = el.querySelector(`button[aria-label="Add consumer group grant for alice"]`) as HTMLButtonElement;
+      addBtn.click();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(userService.addConsumerGroupGrant).toHaveBeenCalledWith('u1', 'orders.*', 'workers');
+      expect(component.grants()['u1']).toHaveLength(1);
+      expect(component.grants()['u1'][0].consumer_group).toBe('workers');
+    });
+
+    it('should reset the form fields after a successful submission', async () => {
+      const user = makeUser({ id: 'u1', username: 'alice' });
+      const { fixture, el, component } = await setup({ users: [user], listGrantsResult: [] });
+
+      const grantsBtn = el.querySelector(`button[aria-label="Toggle grants for alice"]`) as HTMLButtonElement;
+      grantsBtn.click();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      component.newCgPattern.set('events.*');
+      component.newCgGroup.set('my-group');
+
+      const addBtn = el.querySelector(`button[aria-label="Add consumer group grant for alice"]`) as HTMLButtonElement;
+      addBtn.click();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(component.newCgPattern()).toBe('*');
+      expect(component.newCgGroup()).toBe('');
+    });
+
+    it('should show an error banner when consumer group is empty', async () => {
+      const user = makeUser({ id: 'u1', username: 'alice' });
+      const { fixture, el, component } = await setup({ users: [user], listGrantsResult: [] });
+
+      const grantsBtn = el.querySelector(`button[aria-label="Toggle grants for alice"]`) as HTMLButtonElement;
+      grantsBtn.click();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      component.newCgGroup.set('');
+      fixture.detectChanges();
+
+      const addBtn = el.querySelector(`button[aria-label="Add consumer group grant for alice"]`) as HTMLButtonElement;
+      addBtn.click();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(component.grantsError('u1')).toBe('Consumer group is required');
+      expect(el.textContent).toContain('Consumer group is required');
+    });
+
+    it('should show an error banner when the request fails', async () => {
+      const user = makeUser({ id: 'u1', username: 'alice' });
+      const { fixture, el, component } = await setup({
+        users: [user],
+        listGrantsResult: [],
+        addConsumerGroupGrantResult: 'error',
+      });
+
+      const grantsBtn = el.querySelector(`button[aria-label="Toggle grants for alice"]`) as HTMLButtonElement;
+      grantsBtn.click();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      component.newCgGroup.set('workers');
+      fixture.detectChanges();
+
+      const addBtn = el.querySelector(`button[aria-label="Add consumer group grant for alice"]`) as HTMLButtonElement;
+      addBtn.click();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(component.grantsError('u1')).toBe('Failed to add consumer group grant');
+      expect(el.textContent).toContain('Failed to add consumer group grant');
     });
   });
 });

--- a/ui/src/app/admin/users-section.ts
+++ b/ui/src/app/admin/users-section.ts
@@ -298,8 +298,8 @@ import { inputValue } from '../utils/dom';
                                 <input
                                   [id]="'cg-pattern-' + user.id"
                                   type="text"
-                                  [value]="newCgPattern()"
-                                  (input)="newCgPattern.set(inputValue($event))"
+                                  [value]="cgPattern(user.id)"
+                                  (input)="setCgPattern(user.id, $event)"
                                   placeholder="*"
                                   [attr.aria-label]="'Consumer group topic pattern for ' + user.username"
                                   class="px-3 py-1.5 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
@@ -313,8 +313,8 @@ import { inputValue } from '../utils/dom';
                                 <input
                                   [id]="'cg-group-' + user.id"
                                   type="text"
-                                  [value]="newCgGroup()"
-                                  (input)="newCgGroup.set(inputValue($event))"
+                                  [value]="cgGroup(user.id)"
+                                  (input)="setCgGroup(user.id, $event)"
                                   placeholder="group name"
                                   required
                                   [attr.aria-label]="'Consumer group name for ' + user.username"
@@ -361,8 +361,8 @@ export class UsersSection implements OnInit {
   readonly newIsAdmin = signal(false);
   readonly newGrantAction = signal<'read' | 'write' | 'admin'>('read');
   readonly newGrantPattern = signal('*');
-  readonly newCgPattern = signal('*');
-  readonly newCgGroup = signal('');
+  readonly newCgPattern = signal<Record<string, string>>({});
+  readonly newCgGroup = signal<Record<string, string>>({});
   private readonly grantsErrorMap = signal<Record<string, string>>({});
 
   protected readonly inputValue = inputValue;
@@ -373,6 +373,22 @@ export class UsersSection implements OnInit {
 
   grantsError(userId: string): string {
     return this.grantsErrorMap()[userId] ?? '';
+  }
+
+  cgPattern(userId: string): string {
+    return this.newCgPattern()[userId] ?? '*';
+  }
+
+  cgGroup(userId: string): string {
+    return this.newCgGroup()[userId] ?? '';
+  }
+
+  setCgPattern(userId: string, event: Event): void {
+    this.newCgPattern.update((m) => ({ ...m, [userId]: inputValue(event) }));
+  }
+
+  setCgGroup(userId: string, event: Event): void {
+    this.newCgGroup.update((m) => ({ ...m, [userId]: inputValue(event) }));
   }
 
   inputChecked(e: Event): boolean {
@@ -492,6 +508,7 @@ export class UsersSection implements OnInit {
   toggleGrants(userId: string): void {
     if (this.expandedGrantUserId() === userId) {
       this.expandedGrantUserId.set(null);
+      this.grantsErrorMap.update((m) => ({ ...m, [userId]: '' }));
       return;
     }
     this.userSvc.listGrants(userId).subscribe({
@@ -541,22 +558,22 @@ export class UsersSection implements OnInit {
   }
 
   onAddConsumerGroupGrant(userId: string): void {
-    const group = this.newCgGroup().trim();
+    const group = this.cgGroup(userId).trim();
     if (!group) {
       this.grantsErrorMap.update((m) => ({ ...m, [userId]: 'Consumer group is required' }));
       return;
     }
     this.grantsErrorMap.update((m) => ({ ...m, [userId]: '' }));
     this.userSvc
-      .addConsumerGroupGrant(userId, this.newCgPattern() || '*', group)
+      .addConsumerGroupGrant(userId, this.cgPattern(userId) || '*', group)
       .subscribe({
         next: (grant) => {
           this.grants.update((all) => ({
             ...all,
             [userId]: [...(all[userId] ?? []), grant],
           }));
-          this.newCgPattern.set('*');
-          this.newCgGroup.set('');
+          this.newCgPattern.update((m) => ({ ...m, [userId]: '*' }));
+          this.newCgGroup.update((m) => ({ ...m, [userId]: '' }));
         },
         error: (err: unknown) => {
           this.grantsErrorMap.update((m) => ({

--- a/ui/src/app/admin/users-section.ts
+++ b/ui/src/app/admin/users-section.ts
@@ -219,6 +219,7 @@ import { inputValue } from '../utils/dom';
                               <tr>
                                 <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Action</th>
                                 <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Topic Pattern</th>
+                                <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Consumer Group</th>
                                 <th class="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
                               </tr>
                             </thead>
@@ -227,6 +228,7 @@ import { inputValue } from '../utils/dom';
                                 <tr class="hover:bg-gray-50">
                                   <td class="px-3 py-2">{{ grant.action }}</td>
                                   <td class="px-3 py-2 font-mono text-xs">{{ grant.topic_pattern }}</td>
+                                  <td class="px-3 py-2 font-mono text-xs">{{ grant.consumer_group ?? '—' }}</td>
                                   <td class="px-3 py-2">
                                     <button
                                       type="button"
@@ -262,6 +264,7 @@ import { inputValue } from '../utils/dom';
                                     class="w-full px-3 py-1.5 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
                                   />
                                 </td>
+                                <td class="px-3 py-2"></td>
                                 <td class="px-3 py-2">
                                   <button
                                     type="button"
@@ -275,6 +278,59 @@ import { inputValue } from '../utils/dom';
                               </tr>
                             </tbody>
                           </table>
+
+                          @if (grantsError(user.id)) {
+                            <div class="mt-2 p-2 bg-red-50 border border-red-200 text-red-700 rounded text-sm">
+                              {{ grantsError(user.id) }}
+                            </div>
+                          }
+
+                          <div class="mt-4 border border-gray-200 rounded-md overflow-hidden">
+                            <div class="px-3 py-2 bg-gray-100 text-xs font-medium text-gray-500 uppercase tracking-wider">
+                              Add consumer group grant
+                            </div>
+                            <div class="p-3 bg-white flex flex-wrap gap-2 items-end">
+                              <div class="flex flex-col gap-1">
+                                <label
+                                  [attr.for]="'cg-pattern-' + user.id"
+                                  class="text-xs text-gray-500"
+                                >Topic Pattern</label>
+                                <input
+                                  [id]="'cg-pattern-' + user.id"
+                                  type="text"
+                                  [value]="newCgPattern()"
+                                  (input)="newCgPattern.set(inputValue($event))"
+                                  placeholder="*"
+                                  [attr.aria-label]="'Consumer group topic pattern for ' + user.username"
+                                  class="px-3 py-1.5 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                                />
+                              </div>
+                              <div class="flex flex-col gap-1">
+                                <label
+                                  [attr.for]="'cg-group-' + user.id"
+                                  class="text-xs text-gray-500"
+                                >Consumer Group</label>
+                                <input
+                                  [id]="'cg-group-' + user.id"
+                                  type="text"
+                                  [value]="newCgGroup()"
+                                  (input)="newCgGroup.set(inputValue($event))"
+                                  placeholder="group name"
+                                  required
+                                  [attr.aria-label]="'Consumer group name for ' + user.username"
+                                  class="px-3 py-1.5 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                                />
+                              </div>
+                              <button
+                                type="button"
+                                (click)="onAddConsumerGroupGrant(user.id)"
+                                [attr.aria-label]="'Add consumer group grant for ' + user.username"
+                                class="px-3 py-1.5 text-sm font-medium text-white bg-indigo-600 rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 cursor-pointer"
+                              >
+                                Add
+                              </button>
+                            </div>
+                          </div>
                         </div>
                       </td>
                     </tr>
@@ -305,11 +361,18 @@ export class UsersSection implements OnInit {
   readonly newIsAdmin = signal(false);
   readonly newGrantAction = signal<'read' | 'write' | 'admin'>('read');
   readonly newGrantPattern = signal('*');
+  readonly newCgPattern = signal('*');
+  readonly newCgGroup = signal('');
+  private readonly grantsErrorMap = signal<Record<string, string>>({});
 
   protected readonly inputValue = inputValue;
 
   grantsFor(userId: string): Grant[] {
     return this.grants()[userId] ?? [];
+  }
+
+  grantsError(userId: string): string {
+    return this.grantsErrorMap()[userId] ?? '';
   }
 
   inputChecked(e: Event): boolean {
@@ -473,6 +536,33 @@ export class UsersSection implements OnInit {
         },
         error: (err: unknown) => {
           this.error.set(getErrorMessage(err, 'Failed to add grant'));
+        },
+      });
+  }
+
+  onAddConsumerGroupGrant(userId: string): void {
+    const group = this.newCgGroup().trim();
+    if (!group) {
+      this.grantsErrorMap.update((m) => ({ ...m, [userId]: 'Consumer group is required' }));
+      return;
+    }
+    this.grantsErrorMap.update((m) => ({ ...m, [userId]: '' }));
+    this.userSvc
+      .addConsumerGroupGrant(userId, this.newCgPattern() || '*', group)
+      .subscribe({
+        next: (grant) => {
+          this.grants.update((all) => ({
+            ...all,
+            [userId]: [...(all[userId] ?? []), grant],
+          }));
+          this.newCgPattern.set('*');
+          this.newCgGroup.set('');
+        },
+        error: (err: unknown) => {
+          this.grantsErrorMap.update((m) => ({
+            ...m,
+            [userId]: getErrorMessage(err, 'Failed to add consumer group grant'),
+          }));
         },
       });
   }

--- a/ui/src/app/services/user.service.spec.ts
+++ b/ui/src/app/services/user.service.spec.ts
@@ -156,4 +156,45 @@ describe('UserService', () => {
 
     expect(completed).toBe(true);
   });
+
+  describe('addConsumerGroupGrant()', () => {
+    it('should POST to /api/users/:id/consumer-group-grants with topic_pattern and consumer_group', () => {
+      const created = makeGrant({
+        id: 'g-cg',
+        action: 'consume',
+        topic_pattern: 'orders.*',
+        consumer_group: 'my-group',
+      });
+      let result: Grant | undefined;
+
+      service.addConsumerGroupGrant('u1', 'orders.*', 'my-group').subscribe((v) => (result = v));
+
+      const httpReq = httpController.expectOne('/api/users/u1/consumer-group-grants');
+      expect(httpReq.request.method).toBe('POST');
+      expect(httpReq.request.body).toEqual({
+        topic_pattern: 'orders.*',
+        consumer_group: 'my-group',
+      });
+      httpReq.flush(created);
+
+      expect(result).toEqual(created);
+    });
+
+    it('should return the created grant including consumer_group field', () => {
+      const created = makeGrant({
+        id: 'g-cg2',
+        action: 'consume',
+        topic_pattern: '*',
+        consumer_group: 'workers',
+      });
+      let result: Grant | undefined;
+
+      service.addConsumerGroupGrant('u2', '*', 'workers').subscribe((v) => (result = v));
+
+      httpController.expectOne('/api/users/u2/consumer-group-grants').flush(created);
+
+      expect(result?.consumer_group).toBe('workers');
+      expect(result?.action).toBe('consume');
+    });
+  });
 });

--- a/ui/src/app/services/user.service.ts
+++ b/ui/src/app/services/user.service.ts
@@ -14,8 +14,9 @@ export interface User {
 export interface Grant {
   id: string;
   user_id: string;
-  action: 'read' | 'write' | 'admin';
+  action: 'read' | 'write' | 'admin' | 'consume';
   topic_pattern: string;
+  consumer_group?: string;
   created_at: string;
 }
 
@@ -70,5 +71,16 @@ export class UserService {
 
   deleteGrant(userId: string, grantId: string): Observable<void> {
     return this.http.delete<void>(`/api/users/${userId}/grants/${grantId}`);
+  }
+
+  addConsumerGroupGrant(
+    userId: string,
+    topicPattern: string,
+    consumerGroup: string,
+  ): Observable<Grant> {
+    return this.http.post<Grant>(`/api/users/${userId}/consumer-group-grants`, {
+      topic_pattern: topicPattern,
+      consumer_group: consumerGroup,
+    });
   }
 }


### PR DESCRIPTION
## Summary

- Adds a `consume` grant action that restricts a user to specific consumer groups on a topic
- Migration 014 extends `user_grants` with a `consumer_group` column and unique partial index
- `write` and `consume` grants both satisfy dequeue/ack/nack topic checks (`HasDequeueAccess`)
- `HasConsumerGroupAccess` is opt-in: users with no `consume` grants are unrestricted; once any `consume` grant exists for a topic, the user is restricted to explicitly granted groups
- gRPC: `checkDequeueGrant` fetches grants once and checks both topic and group access
- HTTP: `requireDequeueGrant` and `requireDequeueOnMsgTopic` enforce the same policy on dequeue and nack routes
- New admin API endpoint: `POST /api/users/:id/consumer-group-grants`
- Angular admin UI: Consumer Group column in grants table, Add consumer group grant form

## Test plan

- [x] Backend: 379 Ginkgo specs pass including new permissions, users, and HTTP handler tests
- [x] Frontend: 292 Vitest specs pass including new service and UI tests
- [x] CI passes