### PR TITLE
docs: add Java client

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,15 @@ Access the admin UI at `http://localhost:8081` (login: `admin` / `secret`).
 go get github.com/Joessst-Dev/queue-ti/clients/go-client
 npm install @queue-ti/client
 pip install queue-ti-client
-# Java: see docs for GitHub Packages setup
+```
+
+**Java** (GitHub Packages — [see setup instructions](https://joessst-dev.github.io/queue-ti/clients/java)):
+
+```kotlin
 implementation("de.joesst.dev:queue-ti-java-client:VERSION")
 ```
+
+Latest version: [github.com/Joessst-Dev/queue-ti-java-client/releases](https://github.com/Joessst-Dev/queue-ti-java-client/releases)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ If you already run Postgres, you have a production-ready queue. One table, at-le
 - **Fine-grained access control** — JWT auth with per-topic grants and consumer group restrictions
 - **Avro schema validation** — enforce payload contracts at enqueue time
 - **Admin UI** — inspect messages, requeue from DLQ, manage topics and users without writing code
-- **Go, Node.js, and Python clients** — auto-reconnect, token refresh, batch consumption
+- **Go, Node.js, Python, and Java clients** — auto-reconnect, token refresh, batch consumption
 
 ## Quick Start
 
@@ -31,6 +31,8 @@ Access the admin UI at `http://localhost:8081` (login: `admin` / `secret`).
 go get github.com/Joessst-Dev/queue-ti/clients/go-client
 npm install @queue-ti/client
 pip install queue-ti-client
+# Java: see docs for GitHub Packages setup
+implementation("de.joesst.dev:queue-ti-java-client:VERSION")
 ```
 
 ## License

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -45,6 +45,7 @@ export default withMermaid(defineConfig({
             { text: 'Go Client', link: '/clients/go' },
             { text: 'Node.js Client', link: '/clients/nodejs' },
             { text: 'Python Client', link: '/clients/python' },
+            { text: 'Java Client', link: '/clients/java' },
           ],
         },
       ],

--- a/docs/clients/java.md
+++ b/docs/clients/java.md
@@ -1,0 +1,262 @@
+# Java Client
+
+A Java 21 gRPC client library for queue-ti, hosted at [Joessst-Dev/queue-ti-java-client](https://github.com/Joessst-Dev/queue-ti-java-client).
+
+## Requirements
+
+- Java 21 LTS or later
+- Gradle 8+ or Maven 3.9+
+
+## Installation
+
+Releases are published to **GitHub Packages**. GitHub Packages requires authentication even for public repositories, so you need a Personal Access Token (PAT) with the `read:packages` scope.
+
+### 1. Create a Personal Access Token
+
+Go to **GitHub → Settings → Developer settings → Personal access tokens → Tokens (classic)** and generate a token with the `read:packages` scope.
+
+### 2. Store credentials
+
+**Gradle** — add to `~/.gradle/gradle.properties` (never commit this file):
+
+```properties
+gpr.user=your-github-username
+gpr.key=ghp_xxxxxxxxxxxxxxxxxxxx
+```
+
+**Maven** — add to `~/.m2/settings.xml`:
+
+```xml
+<settings>
+  <servers>
+    <server>
+      <id>github-queue-ti</id>
+      <username>your-github-username</username>
+      <password>ghp_xxxxxxxxxxxxxxxxxxxx</password>
+    </server>
+  </servers>
+</settings>
+```
+
+### 3. Declare the repository and dependency
+
+Replace `VERSION` with a release tag (e.g. `2026.05.0`). See [releases](https://github.com/Joessst-Dev/queue-ti-java-client/releases) for available versions.
+
+**Gradle (Kotlin DSL)**
+
+```kotlin
+repositories {
+    maven {
+        url = uri("https://maven.pkg.github.com/Joessst-Dev/queue-ti-java-client")
+        credentials {
+            username = providers.gradleProperty("gpr.user").orNull
+            password = providers.gradleProperty("gpr.key").orNull
+        }
+    }
+}
+
+dependencies {
+    implementation("de.joesst.dev:queue-ti-java-client:VERSION")
+}
+```
+
+**Gradle (Groovy)**
+
+```groovy
+repositories {
+    maven {
+        url 'https://maven.pkg.github.com/Joessst-Dev/queue-ti-java-client'
+        credentials {
+            username = findProperty('gpr.user')
+            password = findProperty('gpr.key')
+        }
+    }
+}
+
+dependencies {
+    implementation 'de.joesst.dev:queue-ti-java-client:VERSION'
+}
+```
+
+**Maven**
+
+```xml
+<repositories>
+    <repository>
+        <id>github-queue-ti</id>
+        <url>https://maven.pkg.github.com/Joessst-Dev/queue-ti-java-client</url>
+    </repository>
+</repositories>
+
+<dependency>
+    <groupId>de.joesst.dev</groupId>
+    <artifactId>queue-ti-java-client</artifactId>
+    <version>VERSION</version>
+</dependency>
+```
+
+### Local build (no token required)
+
+```bash
+git clone https://github.com/Joessst-Dev/queue-ti-java-client.git
+cd queue-ti-java-client
+./gradlew publishToMavenLocal
+```
+
+Then use `mavenLocal()` as the repository and `1.0-SNAPSHOT` as the version.
+
+## Quick Start
+
+```java
+import de.joesst.dev.queueti.*;
+```
+
+### Connect
+
+```java
+try (var client = QueueTiClient.connect("localhost:50051",
+        ConnectOptions.builder().insecure(true).build())) {
+    // use client...
+}
+```
+
+`QueueTiClient` implements `Closeable`. Use try-with-resources to stop the background token-refresher thread and drain in-flight RPCs cleanly. Omit `.insecure(true)` in production — TLS is negotiated automatically.
+
+### Publish a message
+
+```java
+var producer = client.newProducer();
+String messageId = producer.publish("orders", "Hello".getBytes()).get();
+```
+
+With metadata and a deduplication key:
+
+```java
+var options = PublishOptions.builder()
+    .metadata(Map.of("source", "checkout", "version", "1.0"))
+    .key("order-123")
+    .build();
+producer.publish("orders", payload, options).thenAccept(id ->
+    System.out.println("Published: " + id));
+```
+
+### Consume messages (streaming)
+
+```java
+var consumer = client.newConsumer("orders",
+    ConsumerOptions.builder().concurrency(5).consumerGroup("invoicing").build());
+
+consumer.consume(message -> {
+    process(message.payload());
+    return null; // null = ack; throw any exception to nack
+});
+```
+
+`consume()` blocks until the calling thread is interrupted. Messages are dispatched on virtual threads. Automatic exponential-backoff reconnection (500ms–30s) handles stream failures.
+
+### Consume messages (batch polling)
+
+```java
+consumer.consumeBatch(10, messages -> {
+    for (var msg : messages) {
+        if (isPoisonPill(msg)) {
+            msg.nack("unprocessable").join();
+        } else {
+            process(msg.payload());
+        }
+    }
+    return null; // unsettled messages are auto-acked on normal return
+                 // throw to nack all unsettled messages instead
+});
+```
+
+## Configuration
+
+### ConnectOptions
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `insecure` | `boolean` | `false` | Use plaintext channel (no TLS) |
+| `token` | `String` | `null` | Initial JWT sent on every request |
+| `tokenRefresher` | `TokenRefresher` | `null` | Strategy to obtain fresh tokens |
+
+### ConsumerOptions
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `concurrency` | `int` | `1` | Max messages dispatched concurrently |
+| `consumerGroup` | `String` | `""` | Consumer group name |
+| `visibilityTimeoutSeconds` | `Integer` | `null` | Visibility timeout; `null` uses server default |
+
+### PublishOptions
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `metadata` | `Map<String, String>` | empty | Arbitrary key-value pairs attached to the message |
+| `key` | `String` | `null` | Optional deduplication/routing key |
+
+### BatchOptions
+
+Override consumer group or visibility timeout for a single `consumeBatch` call:
+
+```java
+var batchOptions = BatchOptions.builder()
+    .consumerGroup("batch-group")
+    .visibilityTimeoutSeconds(30)
+    .build();
+consumer.consumeBatch(10, handler, batchOptions);
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `consumerGroup` | `String` | `""` | Consumer group for this batch poll |
+| `visibilityTimeoutSeconds` | `Integer` | `null` | Visibility timeout for this batch poll |
+
+## Token Refresh
+
+```java
+TokenRefresher refresher = () -> myAuthClient.fetchToken(); // returns CompletableFuture<String>
+
+var options = ConnectOptions.builder()
+    .token(initialJwt)       // required — refresher won't fire without a parseable token
+    .tokenRefresher(refresher)
+    .build();
+
+try (var client = QueueTiClient.connect("localhost:50051", options)) {
+    // ...
+}
+```
+
+The client wakes a background virtual thread 60 seconds before token expiry. On failure it retries with exponential backoff (5s–60s). You can also update the token imperatively:
+
+```java
+client.setToken(newToken);
+```
+
+## Message fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id()` | `String` | Server-assigned message ID |
+| `topic()` | `String` | Topic the message was published to |
+| `payload()` | `byte[]` | Raw message bytes (defensive copy) |
+| `metadata()` | `Map<String, String>` | Immutable metadata map |
+| `createdAt()` | `Instant` | Enqueue timestamp; `Instant.EPOCH` if unavailable |
+| `retryCount()` | `int` | Number of prior delivery attempts (0 on first delivery) |
+| `maxRetries()` | `OptionalInt` | Server-configured max retries (batch only; empty for streaming) |
+
+```java
+message.ack();                    // CompletableFuture<Void>
+message.nack("processing error"); // CompletableFuture<Void>
+```
+
+## Building from source
+
+```bash
+./gradlew build               # compile + all tests
+./gradlew test                # tests only
+./gradlew generateProto       # regenerate gRPC stubs from proto
+./gradlew publishToMavenLocal # install to ~/.m2
+```
+
+Tests use JUnit 5 with an in-process gRPC server — no external server required.

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,6 +32,9 @@ features:
   - icon: 🔒
     title: JWT Authentication
     details: Optional JWT-based auth with user accounts, role-based access, and per-topic grants. OAuth-ready.
+  - icon: 📦
+    title: Multi-Language Clients
+    details: Official clients for Go, Node.js, Python, and Java — auto-reconnect, token refresh, and batch consumption included.
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds `docs/clients/java.md` with full documentation sourced from [queue-ti-java-client](https://github.com/Joessst-Dev/queue-ti-java-client) README
- Covers installation (Gradle/Maven/local), quick start, streaming and batch consumption, all config options, token refresh, and message fields
- Adds Java to the VitePress sidebar under Client Libraries
- Updates `docs/index.md` feature grid to mention four-language client support
- Updates `README.md` bullet and install snippet to include Java

## Test plan

- [x] `npm run docs:build` passes (verified locally)
- [x] Java page appears in sidebar under Clients
- [x] No dead links