### PR TITLE
feat: Redis-backed cache for schema and topic config

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -101,11 +101,7 @@ func main() {
 	reg := prometheus.NewRegistry()
 	rec := metrics.New(pool, reg)
 
-	broadcaster := broadcast.NewPG(pool)
-	defer broadcaster.Close()
-
 	queueService := queue.NewService(pool, cfg.Queue.VisibilityTimeout, cfg.Queue.MaxRetries, cfg.Queue.MessageTTL, cfg.Queue.DLQThreshold, cfg.Queue.RequireTopicRegistration, rec)
-	queueService.UseBroadcaster(ctx, broadcaster)
 	queueService.StartExpiryReaper(ctx, time.Minute)
 
 	reaperSchedule := cfg.Queue.DeleteReaperSchedule
@@ -144,6 +140,10 @@ func main() {
 		}
 	}()
 
+	pgBroadcaster := broadcast.NewPG(pool)
+	defer pgBroadcaster.Close()
+	var activeBroadcaster broadcast.Broadcaster = pgBroadcaster
+
 	var rateLimitStore fiber.Storage
 	if cfg.Redis.Host != "" {
 		redisCfg := redisstorage.Config{
@@ -161,8 +161,11 @@ func main() {
 		}
 		rateLimitStore = store
 		queueService.UseCache(cache.NewRedis(store))
-		slog.Info("Redis connection verified for rate limiter and cache", "host", cfg.Redis.Host, "port", cfg.Redis.Port)
+		activeBroadcaster = broadcast.NewRedis(store.Conn())
+		slog.Info("Redis connection verified for rate limiter, cache, and broadcaster", "host", cfg.Redis.Host, "port", cfg.Redis.Port)
 	}
+
+	queueService.UseBroadcaster(ctx, activeBroadcaster)
 
 	httpServer := server.NewHTTPServer(queueService, cfg.Server, rateLimitStore, cfg.Auth, reg, userStore, version)
 	httpAddr := fmt.Sprintf(":%d", cfg.Server.HTTPPort)

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -122,27 +122,10 @@ func main() {
 		opts = append(opts, grpc.UnaryInterceptor(auth.UnaryInterceptor(cfg.Auth)))
 	}
 
-	grpcServer := grpc.NewServer(opts...)
-	pb.RegisterQueueServiceServer(grpcServer, server.NewGRPCServer(queueService, userStore))
-
-	addr := fmt.Sprintf(":%d", cfg.Server.Port)
-	lis, err := net.Listen("tcp", addr)
-	if err != nil {
-		slog.Error("failed to listen", "addr", addr, "error", err)
-		os.Exit(1)
-	}
-
-	go func() {
-		slog.Info("gRPC server listening", "addr", addr)
-		if err := grpcServer.Serve(lis); err != nil {
-			slog.Error("gRPC server failed", "error", err)
-			os.Exit(1)
-		}
-	}()
-
-	pgBroadcaster := broadcast.NewPG(pool)
-	defer pgBroadcaster.Close()
-	var activeBroadcaster broadcast.Broadcaster = pgBroadcaster
+	// Select broadcaster and cache before starting servers so no request window
+	// sees the Noop defaults.
+	var activeBroadcaster broadcast.Broadcaster = broadcast.NewPG(pool)
+	defer activeBroadcaster.Close()
 
 	var rateLimitStore fiber.Storage
 	if cfg.Redis.Host != "" {
@@ -166,6 +149,24 @@ func main() {
 	}
 
 	queueService.UseBroadcaster(ctx, activeBroadcaster)
+
+	grpcServer := grpc.NewServer(opts...)
+	pb.RegisterQueueServiceServer(grpcServer, server.NewGRPCServer(queueService, userStore))
+
+	addr := fmt.Sprintf(":%d", cfg.Server.Port)
+	lis, err := net.Listen("tcp", addr)
+	if err != nil {
+		slog.Error("failed to listen", "addr", addr, "error", err)
+		os.Exit(1)
+	}
+
+	go func() {
+		slog.Info("gRPC server listening", "addr", addr)
+		if err := grpcServer.Serve(lis); err != nil {
+			slog.Error("gRPC server failed", "error", err)
+			os.Exit(1)
+		}
+	}()
 
 	httpServer := server.NewHTTPServer(queueService, cfg.Server, rateLimitStore, cfg.Auth, reg, userStore, version)
 	httpAddr := fmt.Sprintf(":%d", cfg.Server.HTTPPort)

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/Joessst-Dev/queue-ti/internal/auth"
 	"github.com/Joessst-Dev/queue-ti/internal/broadcast"
+	"github.com/Joessst-Dev/queue-ti/internal/cache"
 	"github.com/Joessst-Dev/queue-ti/internal/config"
 	"github.com/Joessst-Dev/queue-ti/internal/db"
 	"github.com/Joessst-Dev/queue-ti/internal/metrics"
@@ -159,7 +160,8 @@ func main() {
 			os.Exit(1)
 		}
 		rateLimitStore = store
-		slog.Info("Redis connection verified for rate limiter", "host", cfg.Redis.Host, "port", cfg.Redis.Port)
+		queueService.UseCache(cache.NewRedis(store))
+		slog.Info("Redis connection verified for rate limiter and cache", "host", cfg.Redis.Host, "port", cfg.Redis.Port)
 	}
 
 	httpServer := server.NewHTTPServer(queueService, cfg.Server, rateLimitStore, cfg.Auth, reg, userStore, version)

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.1
 	github.com/prometheus/client_golang v1.23.2
+	github.com/redis/go-redis/v9 v9.18.0
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/spf13/viper v1.21.0
 	github.com/testcontainers/testcontainers-go v0.42.0
@@ -87,7 +88,6 @@ require (
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
-	github.com/redis/go-redis/v9 v9.18.0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/sagikazarmark/locafero v0.11.0 // indirect
 	github.com/shirou/gopsutil/v4 v4.26.3 // indirect

--- a/backend/internal/broadcast/broadcaster.go
+++ b/backend/internal/broadcast/broadcaster.go
@@ -3,8 +3,7 @@ package broadcast
 import "context"
 
 // Broadcaster publishes and receives text notifications across service instances.
-// The PostgreSQL implementation uses LISTEN/NOTIFY; a future Redis implementation
-// will satisfy the same interface, making PG the fallback when Redis is disabled.
+// Redis pub/sub is used when Redis is configured; PostgreSQL LISTEN/NOTIFY is the fallback.
 type Broadcaster interface {
 	// Publish sends payload on channel to all subscribers across all instances.
 	Publish(ctx context.Context, channel, payload string) error

--- a/backend/internal/broadcast/pg_test.go
+++ b/backend/internal/broadcast/pg_test.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/testcontainers/testcontainers-go"
 	tcpostgres "github.com/testcontainers/testcontainers-go/modules/postgres"
+	tcredis "github.com/testcontainers/testcontainers-go/modules/redis"
 	"github.com/testcontainers/testcontainers-go/wait"
 
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -19,9 +20,11 @@ import (
 )
 
 var (
-	suiteCtx     context.Context
-	pgContainer  *tcpostgres.PostgresContainer
-	containerDSN string
+	suiteCtx       context.Context
+	pgContainer    *tcpostgres.PostgresContainer
+	containerDSN   string
+	redisContainer *tcredis.RedisContainer
+	redisAddr      string
 )
 
 func TestMain(m *testing.M) {
@@ -59,9 +62,21 @@ func TestMain(m *testing.M) {
 		host, mappedPort.Num(),
 	)
 
+	redisContainer, err = tcredis.Run(suiteCtx, "redis:7-alpine")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to start redis container: %v\n", err)
+		os.Exit(1)
+	}
+	redisAddr, err = redisContainer.ConnectionString(suiteCtx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to get redis connection string: %v\n", err)
+		os.Exit(1)
+	}
+
 	code := m.Run()
 
 	_ = pgContainer.Terminate(suiteCtx)
+	_ = redisContainer.Terminate(suiteCtx)
 	os.Exit(code)
 }
 

--- a/backend/internal/broadcast/redis.go
+++ b/backend/internal/broadcast/redis.go
@@ -1,0 +1,75 @@
+package broadcast
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// RedisBroadcaster implements Broadcaster using Redis pub/sub.
+// It does not own the underlying client — Close is a no-op.
+type RedisBroadcaster struct {
+	client redis.UniversalClient
+}
+
+func NewRedis(client redis.UniversalClient) *RedisBroadcaster {
+	return &RedisBroadcaster{client: client}
+}
+
+func (r *RedisBroadcaster) Publish(ctx context.Context, channel, payload string) error {
+	return r.client.Publish(ctx, channel, payload).Err()
+}
+
+func (r *RedisBroadcaster) Subscribe(ctx context.Context, channel string) (<-chan string, context.CancelFunc) {
+	subCtx, cancel := context.WithCancel(ctx)
+	ch := make(chan string, 16)
+
+	go func() {
+		defer close(ch)
+		for subCtx.Err() == nil {
+			r.runSubscribeLoop(subCtx, channel, ch)
+			if subCtx.Err() != nil {
+				return
+			}
+			select {
+			case <-time.After(2 * time.Second):
+			case <-subCtx.Done():
+				return
+			}
+		}
+	}()
+
+	return ch, cancel
+}
+
+func (r *RedisBroadcaster) runSubscribeLoop(ctx context.Context, channel string, ch chan<- string) {
+	sub := r.client.Subscribe(ctx, channel)
+	defer func() {
+		if err := sub.Close(); err != nil && ctx.Err() == nil {
+			slog.Error("broadcast: redis subscription close failed", "channel", channel, "error", err)
+		}
+	}()
+
+	msgCh := sub.Channel()
+	for {
+		select {
+		case msg, ok := <-msgCh:
+			if !ok {
+				return
+			}
+			select {
+			case ch <- msg.Payload:
+			case <-ctx.Done():
+				return
+			}
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (r *RedisBroadcaster) Close() error {
+	return nil
+}

--- a/backend/internal/broadcast/redis_test.go
+++ b/backend/internal/broadcast/redis_test.go
@@ -1,0 +1,105 @@
+package broadcast_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/redis/go-redis/v9"
+
+	"github.com/Joessst-Dev/queue-ti/internal/broadcast"
+)
+
+var _ = Describe("Redis broadcaster", func() {
+	var (
+		client *redis.Client
+		rb     *broadcast.RedisBroadcaster
+		ctx    context.Context
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+
+		opts, err := redis.ParseURL(redisAddr)
+		Expect(err).NotTo(HaveOccurred())
+		client = redis.NewClient(opts)
+
+		rb = broadcast.NewRedis(client)
+	})
+
+	AfterEach(func() {
+		Expect(rb.Close()).To(Succeed())
+		Expect(client.Close()).To(Succeed())
+	})
+
+	Describe("Publish then Subscribe", func() {
+		Context("when a payload is published to a channel", func() {
+			It("should be received by a subscriber on that channel", func() {
+				ch, cancel := rb.Subscribe(ctx, broadcast.ChannelSchemaChanged)
+				defer cancel()
+
+				// Allow the subscriber goroutine to send SUBSCRIBE before publishing.
+				time.Sleep(50 * time.Millisecond)
+
+				Expect(rb.Publish(ctx, broadcast.ChannelSchemaChanged, "orders")).To(Succeed())
+
+				Eventually(ch, 3*time.Second).Should(Receive(Equal("orders")))
+			})
+		})
+	})
+
+	Describe("Subscribe receives multiple payloads", func() {
+		Context("when three payloads are published in sequence", func() {
+			It("should deliver all three in order", func() {
+				ch, cancel := rb.Subscribe(ctx, broadcast.ChannelSchemaChanged)
+				defer cancel()
+
+				time.Sleep(50 * time.Millisecond)
+
+				for _, topic := range []string{"alpha", "beta", "gamma"} {
+					Expect(rb.Publish(ctx, broadcast.ChannelSchemaChanged, topic)).To(Succeed())
+				}
+
+				Eventually(ch, 3*time.Second).Should(Receive(Equal("alpha")))
+				Eventually(ch, 3*time.Second).Should(Receive(Equal("beta")))
+				Eventually(ch, 3*time.Second).Should(Receive(Equal("gamma")))
+			})
+		})
+	})
+
+	Describe("Cancel stops the subscriber", func() {
+		Context("when cancel is called", func() {
+			It("should close the channel", func() {
+				ch, cancel := rb.Subscribe(ctx, broadcast.ChannelSchemaChanged)
+
+				cancel()
+
+				Eventually(ch, 3*time.Second).Should(BeClosed())
+			})
+		})
+	})
+
+	Describe("Cross-instance delivery", func() {
+		Context("when two separate broadcaster instances share the same Redis", func() {
+			It("should deliver a publish from one to a subscriber on the other", func() {
+				opts, err := redis.ParseURL(redisAddr)
+				Expect(err).NotTo(HaveOccurred())
+				client2 := redis.NewClient(opts)
+				defer client2.Close()
+
+				rb2 := broadcast.NewRedis(client2)
+				defer rb2.Close()
+
+				ch, cancel := rb2.Subscribe(ctx, broadcast.ChannelConfigChanged)
+				defer cancel()
+
+				time.Sleep(50 * time.Millisecond)
+
+				Expect(rb.Publish(ctx, broadcast.ChannelConfigChanged, "my-topic")).To(Succeed())
+
+				Eventually(ch, 3*time.Second).Should(Receive(Equal("my-topic")))
+			})
+		})
+	})
+})

--- a/backend/internal/cache/cache.go
+++ b/backend/internal/cache/cache.go
@@ -1,0 +1,21 @@
+package cache
+
+import (
+	"context"
+	"time"
+)
+
+// Cache is a simple key-value byte cache with optional TTL.
+type Cache interface {
+	Get(ctx context.Context, key string) ([]byte, error)
+	Set(ctx context.Context, key string, val []byte, ttl time.Duration) error
+	Delete(ctx context.Context, keys ...string) error
+}
+
+// Noop is a no-op Cache used when Redis is not configured.
+// Every operation is a silent no-op, preserving pre-Redis behaviour.
+type Noop struct{}
+
+func (Noop) Get(_ context.Context, _ string) ([]byte, error)                  { return nil, nil }
+func (Noop) Set(_ context.Context, _ string, _ []byte, _ time.Duration) error { return nil }
+func (Noop) Delete(_ context.Context, _ ...string) error                      { return nil }

--- a/backend/internal/cache/redis.go
+++ b/backend/internal/cache/redis.go
@@ -1,0 +1,41 @@
+package cache
+
+import (
+	"context"
+	"time"
+)
+
+// Storage is the narrow subset of fiber.Storage this package needs.
+// Defining it here avoids importing the fiber package into the cache layer.
+// Note: fiber's Storage.Delete accepts a single key, not a variadic slice.
+type Storage interface {
+	Get(key string) ([]byte, error)
+	Set(key string, val []byte, exp time.Duration) error
+	Delete(key string) error
+}
+
+// Redis wraps a fiber-compatible storage backend as a Cache.
+type Redis struct{ store Storage }
+
+// NewRedis returns a Cache backed by the provided Storage implementation.
+// In production this is a *redisstorage.Storage; in tests any Storage works.
+func NewRedis(s Storage) *Redis { return &Redis{store: s} }
+
+func (r *Redis) Get(_ context.Context, key string) ([]byte, error) {
+	return r.store.Get(key)
+}
+
+func (r *Redis) Set(_ context.Context, key string, val []byte, ttl time.Duration) error {
+	return r.store.Set(key, val, ttl)
+}
+
+// Delete deletes each key individually to match the fiber Storage interface,
+// which accepts a single key per call rather than a variadic slice.
+func (r *Redis) Delete(_ context.Context, keys ...string) error {
+	for _, key := range keys {
+		if err := r.store.Delete(key); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/backend/internal/queue/cache_test.go
+++ b/backend/internal/queue/cache_test.go
@@ -72,10 +72,9 @@ func (f *fakeCache) getCount(key string) int {
 
 var _ cache.Cache = (*fakeCache)(nil) // compile-time interface check
 
-// schemaKey returns the Redis cache key for a topic's schema.
+// schemaKey and configKey mirror the private constants in the queue package
+// (schemaCachePrefix, configCachePrefix). Keep in sync if those change.
 func schemaKey(topic string) string { return "queueti:cache:schema:" + topic }
-
-// configKey returns the Redis cache key for a topic's config.
 func configKey(topic string) string { return "queueti:cache:topic_config:" + topic }
 
 var _ = Describe("Schema Cache", func() {

--- a/backend/internal/queue/cache_test.go
+++ b/backend/internal/queue/cache_test.go
@@ -1,0 +1,388 @@
+package queue_test
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/Joessst-Dev/queue-ti/internal/cache"
+	"github.com/Joessst-Dev/queue-ti/internal/db"
+	"github.com/Joessst-Dev/queue-ti/internal/queue"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// fakeCache is a thread-safe in-memory Cache used in tests to observe cache
+// interactions without a real Redis instance.
+type fakeCache struct {
+	mu   sync.Mutex
+	data map[string][]byte
+	gets map[string]int // counts Get calls per key to assert cache hits
+}
+
+func newFakeCache() *fakeCache {
+	return &fakeCache{
+		data: map[string][]byte{},
+		gets: map[string]int{},
+	}
+}
+
+func (f *fakeCache) Get(_ context.Context, key string) ([]byte, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.gets[key]++
+	v, ok := f.data[key]
+	if !ok {
+		return nil, nil
+	}
+	return v, nil
+}
+
+func (f *fakeCache) Set(_ context.Context, key string, val []byte, _ time.Duration) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.data[key] = val
+	return nil
+}
+
+func (f *fakeCache) Delete(_ context.Context, keys ...string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, k := range keys {
+		delete(f.data, k)
+	}
+	return nil
+}
+
+func (f *fakeCache) hasKey(key string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	_, ok := f.data[key]
+	return ok
+}
+
+func (f *fakeCache) getCount(key string) int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.gets[key]
+}
+
+var _ cache.Cache = (*fakeCache)(nil) // compile-time interface check
+
+// schemaKey returns the Redis cache key for a topic's schema.
+func schemaKey(topic string) string { return "queueti:cache:schema:" + topic }
+
+// configKey returns the Redis cache key for a topic's config.
+func configKey(topic string) string { return "queueti:cache:topic_config:" + topic }
+
+var _ = Describe("Schema Cache", func() {
+	var (
+		pool    *pgxpool.Pool
+		svc     *queue.Service
+		fc      *fakeCache
+		ctx     context.Context
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+
+		var err error
+		pool, err = pgxpool.New(ctx, containerDSN)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = db.Migrate(ctx, pool)
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = pool.Exec(ctx, "DELETE FROM topic_schemas")
+		Expect(err).NotTo(HaveOccurred())
+		_, err = pool.Exec(ctx, "DELETE FROM messages")
+		Expect(err).NotTo(HaveOccurred())
+
+		fc = newFakeCache()
+		svc = queue.NewService(pool, 30*time.Second, 3, 0, 3, false, queue.NoopRecorder{})
+		svc.UseCache(fc)
+	})
+
+	AfterEach(func() {
+		if pool != nil {
+			pool.Close()
+		}
+	})
+
+	Describe("getTopicSchemaCached (exercised via Enqueue)", func() {
+		Context("when a schema is registered and the cache is cold", func() {
+			BeforeEach(func() {
+				_, err := queue.UpsertTopicSchema(ctx, pool, "cached-schema-topic", validRecordSchema)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should fetch from DB and populate Redis on cache miss", func() {
+				_, err := svc.Enqueue(ctx, "cached-schema-topic", []byte(`{"id":"x","value":1}`), nil, nil)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(fc.hasKey(schemaKey("cached-schema-topic"))).To(BeTrue(),
+					"expected cache to be populated after the first enqueue")
+			})
+
+			It("should return schema from Redis cache on second call without hitting the DB", func() {
+				// First call — populates cache.
+				_, err := svc.Enqueue(ctx, "cached-schema-topic", []byte(`{"id":"x","value":1}`), nil, nil)
+				Expect(err).NotTo(HaveOccurred())
+
+				getsAfterFirst := fc.getCount(schemaKey("cached-schema-topic"))
+
+				// Second call — should hit cache, not DB. The Get count increments
+				// whether it's a hit or miss, so we confirm the entry is still present.
+				_, err = svc.Enqueue(ctx, "cached-schema-topic", []byte(`{"id":"y","value":2}`), nil, nil)
+				Expect(err).NotTo(HaveOccurred())
+
+				getsAfterSecond := fc.getCount(schemaKey("cached-schema-topic"))
+				Expect(getsAfterSecond).To(Equal(getsAfterFirst+1),
+					"expected exactly one more cache.Get call — the second enqueue hit the cache")
+
+				Expect(fc.hasKey(schemaKey("cached-schema-topic"))).To(BeTrue())
+			})
+		})
+
+		Context("when no schema is registered for a topic", func() {
+			It("should cache a nil-sentinel so subsequent calls skip the DB", func() {
+				// Enqueue twice with no schema — both should succeed.
+				_, err := svc.Enqueue(ctx, "no-schema-topic", []byte(`anything`), nil, nil)
+				Expect(err).NotTo(HaveOccurred())
+
+				_, err = svc.Enqueue(ctx, "no-schema-topic", []byte(`anything else`), nil, nil)
+				Expect(err).NotTo(HaveOccurred())
+
+				// Cache must hold the sentinel after the first miss.
+				Expect(fc.hasKey(schemaKey("no-schema-topic"))).To(BeTrue())
+
+				// Second enqueue must have made exactly one more cache.Get than the first.
+				Expect(fc.getCount(schemaKey("no-schema-topic"))).To(Equal(2))
+			})
+		})
+	})
+
+	Describe("UpsertTopicSchemaAndNotify", func() {
+		Context("when an existing schema is updated", func() {
+			It("should invalidate the Redis cache so the next call re-fetches from DB", func() {
+				// Seed the cache via an initial enqueue.
+				_, err := queue.UpsertTopicSchema(ctx, pool, "upsert-cache-topic", validRecordSchema)
+				Expect(err).NotTo(HaveOccurred())
+				_, err = svc.Enqueue(ctx, "upsert-cache-topic", []byte(`{"id":"a","value":1}`), nil, nil)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(fc.hasKey(schemaKey("upsert-cache-topic"))).To(BeTrue())
+
+				// Upsert via the service method — must delete the cache entry.
+				_, err = svc.UpsertTopicSchemaAndNotify(ctx, "upsert-cache-topic", validRecordSchema)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(fc.hasKey(schemaKey("upsert-cache-topic"))).To(BeFalse(),
+					"expected cache to be invalidated after UpsertTopicSchemaAndNotify")
+			})
+		})
+	})
+
+	Describe("DeleteTopicSchemaAndNotify", func() {
+		Context("when a schema is deleted via the service", func() {
+			It("should invalidate the Redis cache entry for that topic", func() {
+				_, err := queue.UpsertTopicSchema(ctx, pool, "delete-cache-topic", validRecordSchema)
+				Expect(err).NotTo(HaveOccurred())
+				_, err = svc.Enqueue(ctx, "delete-cache-topic", []byte(`{"id":"a","value":1}`), nil, nil)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(fc.hasKey(schemaKey("delete-cache-topic"))).To(BeTrue())
+
+				err = svc.DeleteTopicSchemaAndNotify(ctx, "delete-cache-topic")
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(fc.hasKey(schemaKey("delete-cache-topic"))).To(BeFalse(),
+					"expected cache to be invalidated after DeleteTopicSchemaAndNotify")
+			})
+		})
+	})
+})
+
+var _ = Describe("Topic Config Cache", func() {
+	var (
+		pool *pgxpool.Pool
+		svc  *queue.Service
+		fc   *fakeCache
+		ctx  context.Context
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+
+		var err error
+		pool, err = pgxpool.New(ctx, containerDSN)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = db.Migrate(ctx, pool)
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = pool.Exec(ctx, "DELETE FROM topic_config")
+		Expect(err).NotTo(HaveOccurred())
+
+		fc = newFakeCache()
+		svc = queue.NewService(pool, 30*time.Second, 3, 0, 3, false, queue.NoopRecorder{})
+		svc.UseCache(fc)
+	})
+
+	AfterEach(func() {
+		if pool != nil {
+			pool.Close()
+		}
+	})
+
+	Describe("GetTopicConfig", func() {
+		Context("when a config exists and the caches are cold", func() {
+			BeforeEach(func() {
+				maxRetries := 5
+				err := svc.UpsertTopicConfig(ctx, queue.TopicConfig{
+					Topic:      "config-cache-topic",
+					MaxRetries: &maxRetries,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				// UpsertTopicConfig invalidates both caches — confirm they are empty.
+				Expect(fc.hasKey(configKey("config-cache-topic"))).To(BeFalse())
+			})
+
+			It("should populate both local and Redis cache on DB fetch", func() {
+				cfg, err := svc.GetTopicConfig(ctx, "config-cache-topic")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cfg).NotTo(BeNil())
+
+				Expect(fc.hasKey(configKey("config-cache-topic"))).To(BeTrue(),
+					"expected Redis cache to be populated after a DB fetch")
+			})
+
+			It("should return config from local cache on second call without hitting Redis or DB", func() {
+				// First call populates both caches.
+				_, err := svc.GetTopicConfig(ctx, "config-cache-topic")
+				Expect(err).NotTo(HaveOccurred())
+
+				getsAfterFirst := fc.getCount(configKey("config-cache-topic"))
+
+				// Second call should hit the local sync.Map — no Redis Get needed.
+				cfg, err := svc.GetTopicConfig(ctx, "config-cache-topic")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cfg).NotTo(BeNil())
+
+				Expect(fc.getCount(configKey("config-cache-topic"))).To(Equal(getsAfterFirst),
+					"expected zero additional Redis.Get calls on second lookup (local cache hit)")
+			})
+		})
+
+		Context("when no config exists for the topic", func() {
+			It("should cache a nil result and not re-query the DB", func() {
+				cfg, err := svc.GetTopicConfig(ctx, "nonexistent-config-topic")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cfg).To(BeNil())
+
+				// Redis must hold the sentinel.
+				Expect(fc.hasKey(configKey("nonexistent-config-topic"))).To(BeTrue())
+
+				// Second call must not add another Redis.Get (local cache holds the nil).
+				getsAfterFirst := fc.getCount(configKey("nonexistent-config-topic"))
+
+				cfg, err = svc.GetTopicConfig(ctx, "nonexistent-config-topic")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cfg).To(BeNil())
+
+				Expect(fc.getCount(configKey("nonexistent-config-topic"))).To(Equal(getsAfterFirst),
+					"expected zero additional Redis.Get calls — nil result is in local cache")
+			})
+		})
+
+		Context("when a cached config is returned from Redis (local cache is cold)", func() {
+			It("should deserialise and return the config without hitting the DB", func() {
+				maxRetries := 7
+				cfg := queue.TopicConfig{Topic: "redis-only-topic", MaxRetries: &maxRetries}
+
+				encoded, err := json.Marshal(cfg)
+				Expect(err).NotTo(HaveOccurred())
+				err = fc.Set(ctx, configKey("redis-only-topic"), encoded, 30*time.Second)
+				Expect(err).NotTo(HaveOccurred())
+
+				// Create a fresh service sharing the same fakeCache — local cache is empty.
+				svc2 := queue.NewService(pool, 30*time.Second, 3, 0, 3, false, queue.NoopRecorder{})
+				svc2.UseCache(fc)
+
+				result, err := svc2.GetTopicConfig(ctx, "redis-only-topic")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).NotTo(BeNil())
+				Expect(*result.MaxRetries).To(Equal(7))
+			})
+		})
+	})
+
+	Describe("UpsertTopicConfig", func() {
+		Context("when a config is upserted", func() {
+			It("should invalidate both local and Redis caches", func() {
+				maxRetries := 3
+				err := svc.UpsertTopicConfig(ctx, queue.TopicConfig{
+					Topic:      "invalidate-upsert-topic",
+					MaxRetries: &maxRetries,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				// Warm both caches.
+				_, err = svc.GetTopicConfig(ctx, "invalidate-upsert-topic")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(fc.hasKey(configKey("invalidate-upsert-topic"))).To(BeTrue())
+
+				// Upsert again — must evict both caches.
+				maxRetries = 10
+				err = svc.UpsertTopicConfig(ctx, queue.TopicConfig{
+					Topic:      "invalidate-upsert-topic",
+					MaxRetries: &maxRetries,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(fc.hasKey(configKey("invalidate-upsert-topic"))).To(BeFalse(),
+					"expected Redis cache to be cleared after UpsertTopicConfig")
+
+				// Next Get must re-populate from DB with the updated value.
+				cfg, err := svc.GetTopicConfig(ctx, "invalidate-upsert-topic")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cfg).NotTo(BeNil())
+				Expect(*cfg.MaxRetries).To(Equal(10))
+			})
+		})
+	})
+
+	Describe("DeleteTopicConfig", func() {
+		Context("when a config is deleted", func() {
+			It("should invalidate both local and Redis caches", func() {
+				maxRetries := 2
+				err := svc.UpsertTopicConfig(ctx, queue.TopicConfig{
+					Topic:      "invalidate-delete-topic",
+					MaxRetries: &maxRetries,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				// Warm both caches.
+				_, err = svc.GetTopicConfig(ctx, "invalidate-delete-topic")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(fc.hasKey(configKey("invalidate-delete-topic"))).To(BeTrue())
+
+				// Delete — must evict both caches.
+				err = svc.DeleteTopicConfig(ctx, "invalidate-delete-topic")
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(fc.hasKey(configKey("invalidate-delete-topic"))).To(BeFalse(),
+					"expected Redis cache to be cleared after DeleteTopicConfig")
+
+				// Next Get must re-query DB and return nil.
+				cfg, err := svc.GetTopicConfig(ctx, "invalidate-delete-topic")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cfg).To(BeNil())
+			})
+		})
+	})
+})

--- a/backend/internal/queue/schema.go
+++ b/backend/internal/queue/schema.go
@@ -174,10 +174,11 @@ func (s *Service) getTopicSchemaCached(ctx context.Context, topic string) (*Topi
 		if jsonErr := json.Unmarshal(raw, &ts); jsonErr == nil {
 			return &ts, nil
 		}
-		// Corrupted cache entry — fall through to DB.
+		// Corrupted cache entry — evict it so other instances don't repeat the fallback.
+		_ = s.cache.Delete(ctx, cacheKey)
 	}
 
-	// L2: Database
+	// L3: Database
 	ts, err := GetTopicSchema(ctx, s.pool, topic)
 	if err != nil {
 		return nil, err

--- a/backend/internal/queue/schema.go
+++ b/backend/internal/queue/schema.go
@@ -21,6 +21,12 @@ var (
 	ErrInvalidSchema    = errors.New("invalid avro schema")
 )
 
+// schemaNotFoundSentinel is stored in Redis to cache a "no schema" result,
+// preventing repeated DB round-trips when no schema has been registered.
+const schemaNotFoundSentinel = "null"
+const schemaCachePrefix      = "queueti:cache:schema:"
+const schemaCacheTTL         = 30 * time.Second
+
 // TopicSchema holds the registered Avro schema for a single topic.
 type TopicSchema struct {
 	Topic      string
@@ -129,6 +135,7 @@ func (s *Service) UpsertTopicSchemaAndNotify(ctx context.Context, topic, schemaJ
 	if err != nil {
 		return nil, err
 	}
+	_ = s.cache.Delete(ctx, schemaCachePrefix+topic)
 	if err := s.broadcaster.Publish(ctx, broadcast.ChannelSchemaChanged, topic); err != nil {
 		slog.Warn("broadcast schema change failed", "topic", topic, "error", err)
 	}
@@ -139,10 +146,49 @@ func (s *Service) DeleteTopicSchemaAndNotify(ctx context.Context, topic string) 
 	if err := DeleteTopicSchema(ctx, s.pool, topic); err != nil {
 		return err
 	}
+	_ = s.cache.Delete(ctx, schemaCachePrefix+topic)
 	if err := s.broadcaster.Publish(ctx, broadcast.ChannelSchemaChanged, topic); err != nil {
 		slog.Warn("broadcast schema delete failed", "topic", topic, "error", err)
 	}
 	return nil
+}
+
+// getTopicSchemaCached returns the TopicSchema for the given topic, consulting
+// the distributed cache (Redis when configured) before falling back to the DB.
+// A "null" sentinel in Redis represents a confirmed absent schema so we don't
+// query the DB on every enqueue when no schema is registered.
+func (s *Service) getTopicSchemaCached(ctx context.Context, topic string) (*TopicSchema, error) {
+	cacheKey := schemaCachePrefix + topic
+
+	// L1: Redis cache
+	raw, err := s.cache.Get(ctx, cacheKey)
+	if err == nil && raw != nil {
+		if string(raw) == schemaNotFoundSentinel {
+			return nil, nil
+		}
+		var ts TopicSchema
+		if jsonErr := json.Unmarshal(raw, &ts); jsonErr == nil {
+			return &ts, nil
+		}
+		// Corrupted cache entry — fall through to DB.
+	}
+
+	// L2: Database
+	ts, err := GetTopicSchema(ctx, s.pool, topic)
+	if err != nil {
+		return nil, err
+	}
+
+	// Populate cache: sentinel for absent, JSON for present.
+	if ts == nil {
+		_ = s.cache.Set(ctx, cacheKey, []byte(schemaNotFoundSentinel), schemaCacheTTL)
+	} else {
+		if encoded, encErr := json.Marshal(ts); encErr == nil {
+			_ = s.cache.Set(ctx, cacheKey, encoded, schemaCacheTTL)
+		}
+	}
+
+	return ts, nil
 }
 
 // validatePayload checks the payload against the topic's registered Avro schema.
@@ -159,7 +205,7 @@ func (s *Service) DeleteTopicSchemaAndNotify(ctx context.Context, topic string) 
 // Compiled schemas are cached in memory keyed by (topic, version), so
 // avro.Parse is only invoked when the schema version changes.
 func (s *Service) validatePayload(ctx context.Context, topic string, payload []byte) error {
-	ts, err := GetTopicSchema(ctx, s.pool, topic)
+	ts, err := s.getTopicSchemaCached(ctx, topic)
 	if err != nil {
 		return err
 	}

--- a/backend/internal/queue/schema.go
+++ b/backend/internal/queue/schema.go
@@ -21,9 +21,9 @@ var (
 	ErrInvalidSchema    = errors.New("invalid avro schema")
 )
 
-// schemaNotFoundSentinel is stored in Redis to cache a "no schema" result,
-// preventing repeated DB round-trips when no schema has been registered.
-const schemaNotFoundSentinel = "null"
+// cacheNotFoundSentinel is stored in Redis to represent a confirmed DB miss,
+// preventing repeated round-trips for topics with no schema or no config.
+const cacheNotFoundSentinel = "null"
 const schemaCachePrefix      = "queueti:cache:schema:"
 const schemaCacheTTL         = 30 * time.Second
 
@@ -155,15 +155,19 @@ func (s *Service) DeleteTopicSchemaAndNotify(ctx context.Context, topic string) 
 
 // getTopicSchemaCached returns the TopicSchema for the given topic, consulting
 // the distributed cache (Redis when configured) before falling back to the DB.
-// A "null" sentinel in Redis represents a confirmed absent schema so we don't
-// query the DB on every enqueue when no schema is registered.
+// A sentinel in Redis represents a confirmed absent schema so we don't query
+// the DB on every enqueue when no schema is registered.
+//
+// Note: there is no local in-process tier for the raw TopicSchema. The local
+// globalSchemaCache holds compiled avro.Schema objects (L1); Redis holds the
+// raw TopicSchema JSON (L2); the DB is the source of truth (L3).
 func (s *Service) getTopicSchemaCached(ctx context.Context, topic string) (*TopicSchema, error) {
 	cacheKey := schemaCachePrefix + topic
 
-	// L1: Redis cache
+	// L2: Redis cache (L1 for compiled avro.Schema is in globalSchemaCache)
 	raw, err := s.cache.Get(ctx, cacheKey)
 	if err == nil && raw != nil {
-		if string(raw) == schemaNotFoundSentinel {
+		if string(raw) == cacheNotFoundSentinel {
 			return nil, nil
 		}
 		var ts TopicSchema
@@ -181,7 +185,7 @@ func (s *Service) getTopicSchemaCached(ctx context.Context, topic string) (*Topi
 
 	// Populate cache: sentinel for absent, JSON for present.
 	if ts == nil {
-		_ = s.cache.Set(ctx, cacheKey, []byte(schemaNotFoundSentinel), schemaCacheTTL)
+		_ = s.cache.Set(ctx, cacheKey, []byte(cacheNotFoundSentinel), schemaCacheTTL)
 	} else {
 		if encoded, encErr := json.Marshal(ts); encErr == nil {
 			_ = s.cache.Set(ctx, cacheKey, encoded, schemaCacheTTL)

--- a/backend/internal/queue/service.go
+++ b/backend/internal/queue/service.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/Joessst-Dev/queue-ti/internal/broadcast"
+	"github.com/Joessst-Dev/queue-ti/internal/cache"
 )
 
 var (
@@ -67,6 +68,8 @@ type Service struct {
 	requireTopicRegistration bool
 	recorder                 MetricsRecorder
 	broadcaster              broadcast.Broadcaster
+	cache                    cache.Cache
+	topicConfigCache         sync.Map // stores topicConfigEntry{cfg *TopicConfig}
 
 	deleteReaperMu   sync.Mutex
 	deleteReaperStop func()
@@ -92,7 +95,15 @@ func NewService(pool *pgxpool.Pool, visibilityTimeout time.Duration, maxRetries 
 		requireTopicRegistration: requireTopicRegistration,
 		recorder:                 recorder,
 		broadcaster:              broadcast.Noop{},
+		cache:                    cache.Noop{},
 	}
+}
+
+// UseCache sets the distributed cache used for schema and topic config lookups.
+// Call once at startup after NewService. When not called the service uses a
+// no-op cache and behaviour is identical to before Redis was introduced.
+func (s *Service) UseCache(c cache.Cache) {
+	s.cache = c
 }
 
 // UseBroadcaster sets the broadcaster and immediately starts the channel
@@ -104,7 +115,8 @@ func (s *Service) UseBroadcaster(ctx context.Context, b broadcast.Broadcaster) {
 		slog.Info("schema cache invalidated via broadcast", "topic", topic)
 	})
 	go s.listenChannel(ctx, broadcast.ChannelConfigChanged, func(topic string) {
-		slog.Info("config change received via broadcast", "topic", topic)
+		s.topicConfigCache.Delete(topic)
+		slog.Info("topic config cache invalidated via broadcast", "topic", topic)
 	})
 }
 

--- a/backend/internal/queue/topic_config.go
+++ b/backend/internal/queue/topic_config.go
@@ -2,15 +2,24 @@ package queue
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 
 	"github.com/Joessst-Dev/queue-ti/internal/broadcast"
 )
+
+// topicConfigEntry wraps a *TopicConfig in the local sync.Map cache.
+// A nil cfg field means "queried DB and confirmed no config exists".
+type topicConfigEntry struct{ cfg *TopicConfig }
+
+const configCachePrefix = "queueti:cache:topic_config:"
+const configCacheTTL    = 30 * time.Second
 
 // TopicConfig holds per-topic overrides. A nil pointer field means "use global default".
 type TopicConfig struct {
@@ -24,6 +33,28 @@ type TopicConfig struct {
 }
 
 func (s *Service) GetTopicConfig(ctx context.Context, topic string) (*TopicConfig, error) {
+	// L1: in-process sync.Map — fastest path, no serialisation overhead.
+	if v, ok := s.topicConfigCache.Load(topic); ok {
+		return v.(topicConfigEntry).cfg, nil
+	}
+
+	cacheKey := configCachePrefix + topic
+
+	// L2: distributed cache (Redis when configured).
+	if raw, err := s.cache.Get(ctx, cacheKey); err == nil && raw != nil {
+		if string(raw) == schemaNotFoundSentinel {
+			s.topicConfigCache.Store(topic, topicConfigEntry{cfg: nil})
+			return nil, nil
+		}
+		var cfg TopicConfig
+		if jsonErr := json.Unmarshal(raw, &cfg); jsonErr == nil {
+			s.topicConfigCache.Store(topic, topicConfigEntry{cfg: &cfg})
+			return &cfg, nil
+		}
+		// Corrupted entry — fall through to DB.
+	}
+
+	// L3: database.
 	var cfg TopicConfig
 	err := s.pool.QueryRow(ctx,
 		`SELECT topic, max_retries, message_ttl_seconds, max_depth, replayable, replay_window_seconds,
@@ -33,10 +64,17 @@ func (s *Service) GetTopicConfig(ctx context.Context, topic string) (*TopicConfi
 	).Scan(&cfg.Topic, &cfg.MaxRetries, &cfg.MessageTTLSeconds, &cfg.MaxDepth, &cfg.Replayable, &cfg.ReplayWindowSeconds,
 		&cfg.ThroughputLimit)
 	if errors.Is(err, pgx.ErrNoRows) {
+		s.topicConfigCache.Store(topic, topicConfigEntry{cfg: nil})
+		_ = s.cache.Set(ctx, cacheKey, []byte(schemaNotFoundSentinel), configCacheTTL)
 		return nil, nil
 	}
 	if err != nil {
 		return nil, fmt.Errorf("get topic config: %w", err)
+	}
+
+	s.topicConfigCache.Store(topic, topicConfigEntry{cfg: &cfg})
+	if encoded, encErr := json.Marshal(&cfg); encErr == nil {
+		_ = s.cache.Set(ctx, cacheKey, encoded, configCacheTTL)
 	}
 	return &cfg, nil
 }
@@ -61,6 +99,8 @@ func (s *Service) UpsertTopicConfig(ctx context.Context, cfg TopicConfig) error 
 	if err != nil {
 		return fmt.Errorf("upsert topic config: %w", err)
 	}
+	s.topicConfigCache.Delete(cfg.Topic)
+	_ = s.cache.Delete(ctx, configCachePrefix+cfg.Topic)
 	if err := s.broadcaster.Publish(ctx, broadcast.ChannelConfigChanged, cfg.Topic); err != nil {
 		slog.Warn("broadcast config change failed", "topic", cfg.Topic, "error", err)
 	}
@@ -78,6 +118,8 @@ func (s *Service) DeleteTopicConfig(ctx context.Context, topic string) error {
 	if _, err := s.pool.Exec(ctx, `DELETE FROM topic_throughput WHERE topic = $1`, topic); err != nil {
 		return fmt.Errorf("delete topic throughput: %w", err)
 	}
+	s.topicConfigCache.Delete(topic)
+	_ = s.cache.Delete(ctx, configCachePrefix+topic)
 	if err := s.broadcaster.Publish(ctx, broadcast.ChannelConfigChanged, topic); err != nil {
 		slog.Warn("broadcast config delete failed", "topic", topic, "error", err)
 	}

--- a/backend/internal/queue/topic_config.go
+++ b/backend/internal/queue/topic_config.go
@@ -51,7 +51,8 @@ func (s *Service) GetTopicConfig(ctx context.Context, topic string) (*TopicConfi
 			s.topicConfigCache.Store(topic, topicConfigEntry{cfg: &cfg})
 			return &cfg, nil
 		}
-		// Corrupted entry — fall through to DB.
+		// Corrupted entry — evict it so other instances don't repeat the fallback.
+		_ = s.cache.Delete(ctx, cacheKey)
 	}
 
 	// L3: database.

--- a/backend/internal/queue/topic_config.go
+++ b/backend/internal/queue/topic_config.go
@@ -42,7 +42,7 @@ func (s *Service) GetTopicConfig(ctx context.Context, topic string) (*TopicConfi
 
 	// L2: distributed cache (Redis when configured).
 	if raw, err := s.cache.Get(ctx, cacheKey); err == nil && raw != nil {
-		if string(raw) == schemaNotFoundSentinel {
+		if string(raw) == cacheNotFoundSentinel {
 			s.topicConfigCache.Store(topic, topicConfigEntry{cfg: nil})
 			return nil, nil
 		}
@@ -65,7 +65,7 @@ func (s *Service) GetTopicConfig(ctx context.Context, topic string) (*TopicConfi
 		&cfg.ThroughputLimit)
 	if errors.Is(err, pgx.ErrNoRows) {
 		s.topicConfigCache.Store(topic, topicConfigEntry{cfg: nil})
-		_ = s.cache.Set(ctx, cacheKey, []byte(schemaNotFoundSentinel), configCacheTTL)
+		_ = s.cache.Set(ctx, cacheKey, []byte(cacheNotFoundSentinel), configCacheTTL)
 		return nil, nil
 	}
 	if err != nil {

--- a/docs/guide/concepts.md
+++ b/docs/guide/concepts.md
@@ -207,3 +207,5 @@ curl -u admin:secret -X PUT http://localhost:8080/api/topic-configs/orders \
 ```
 
 The admin UI **Config** tab allows interactive viewing and editing of all topic configurations without server restart.
+
+**Caching:** Topic configs are cached (like schemas) to avoid repeated database lookups. When Redis is configured, configs are cached in two tiers (in-process + Redis) with a 30-second TTL; changes to a config automatically invalidate caches across all instances via Redis pub/sub.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -152,11 +152,11 @@ Redis is optional but recommended for production deployments. When configured, R
 - Rate limiter: In-memory, per-instance (suitable for single-instance deployments)
 - Cache: In-process only, invalidation via PostgreSQL LISTEN/NOTIFY
 - Broadcaster: PostgreSQL LISTEN/NOTIFY (single-instance friendly)
-- Trade-off: Simpler setup, but repeated DB lookups in single-instance; less efficient multi-instance cache coherence
+- Trade-off: Simpler setup, but multiple instances don't share cached state — each instance has its own L1 cache
 
 **With Redis:**
 - Rate limiter: Shared Redis counter across all instances
-- Cache: Two-tier (in-process L1 + Redis L2), zero overhead if Redis is unavailable (falls back to DB)
+- Cache: Two-tier (in-process L1 + Redis L2); L1 protects warm entries, Redis errors degrade gracefully to DB
 - Broadcaster: Redis pub/sub (faster, more reliable for multi-instance)
 - Trade-off: Additional infrastructure, but significant performance gains in multi-instance deployments
 
@@ -201,7 +201,7 @@ When a schema or config does not exist in the database, a sentinel value (`"null
 - When a schema is registered, updated, or deleted, the local cache is evicted and a broadcast is sent to all instances
 - When a topic config is created, updated, or deleted, the local cache is evicted and a broadcast is sent to all instances
 - Without Redis, invalidation uses PostgreSQL LISTEN/NOTIFY (all instances receive the notification in real time)
-- With Redis, invalidation uses Redis pub/sub (faster, more reliable in high-latency networks)
+- With Redis, invalidation uses Redis pub/sub (purpose-built for messaging, lower overhead than holding a dedicated DB connection per listener)
 
 ### Login Rate Limiter
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -138,23 +138,31 @@ curl -X POST http://localhost:8080/api/messages \
 - Microservices architectures with schema registries (topics are registered alongside schemas)
 - Teams that want producer errors on typos rather than silent failures
 
-## Redis Rate Limiter
+## Redis Integration
 
-The login endpoint (`POST /api/auth/login`) is protected by a rate limiter that prevents brute-force authentication attacks. By default, the rate limiter uses in-memory storage. For multi-replica deployments, configure Redis to share rate-limit state across all backend instances.
+Redis is optional but recommended for production deployments. When configured, Redis powers three critical features:
 
-**Default behavior (in-memory):**
-- Rate limit: 10 requests per 60-second window per client IP
-- Storage: In-memory; each instance has its own rate-limit counter
-- Suitable for: Single-instance deployments, development, testing
+1. **Login rate limiter** — Prevents brute-force authentication attacks (shared state across instances)
+2. **Distributed cache** — Two-tier caching for schema and topic config lookups (in-process + Redis)
+3. **Cross-instance broadcaster** — Invalidates caches on all instances when schemas or configs change
 
-**With Redis (shared state):**
-- Rate limit: 10 requests per 60-second window per client IP (same limit, shared across instances)
-- Storage: Redis; all backend instances query the same counter
-- Suitable for: Multi-replica deployments, load-balanced production setups
+### When Redis is Enabled vs. Disabled
 
-### Enabling Redis Rate Limiter
+**Without Redis:**
+- Rate limiter: In-memory, per-instance (suitable for single-instance deployments)
+- Cache: In-process only, invalidation via PostgreSQL LISTEN/NOTIFY
+- Broadcaster: PostgreSQL LISTEN/NOTIFY (single-instance friendly)
+- Trade-off: Simpler setup, but repeated DB lookups in single-instance; less efficient multi-instance cache coherence
 
-To enable Redis-backed rate limiting, set the `redis.host` configuration:
+**With Redis:**
+- Rate limiter: Shared Redis counter across all instances
+- Cache: Two-tier (in-process L1 + Redis L2), zero overhead if Redis is unavailable (falls back to DB)
+- Broadcaster: Redis pub/sub (faster, more reliable for multi-instance)
+- Trade-off: Additional infrastructure, but significant performance gains in multi-instance deployments
+
+### Enabling Redis
+
+To enable Redis, set the `redis.host` configuration:
 
 ```yaml
 redis:
@@ -173,13 +181,48 @@ QUEUETI_REDIS_PASSWORD=your-redis-password
 QUEUETI_REDIS_TLS_ENABLED=true
 ```
 
-When `QUEUETI_REDIS_HOST` is empty or unset, the rate limiter falls back to in-memory storage automatically.
+When `QUEUETI_REDIS_HOST` is empty or unset, Redis is disabled, and the service falls back to in-memory storage and PostgreSQL LISTEN/NOTIFY.
 
-### Redis Connection
+### Distributed Caching
+
+Schema and topic config lookups use a two-tier cache:
+
+- **L1 (in-process)**: `sync.Map` of compiled schemas and configs, fastest access
+- **L2 (Redis)**: JSON-serialized schemas and configs, shared across instances, survives restarts
+- **L3 (PostgreSQL)**: Source of truth
+
+**Cache keys:**
+- Schemas: `queueti:cache:schema:<topic>` (TTL 30 seconds)
+- Topic configs: `queueti:cache:topic_config:<topic>` (TTL 30 seconds)
+
+When a schema or config does not exist in the database, a sentinel value (`"null"`) is stored in Redis to prevent repeated lookups for 30 seconds.
+
+**Invalidation:**
+- When a schema is registered, updated, or deleted, the local cache is evicted and a broadcast is sent to all instances
+- When a topic config is created, updated, or deleted, the local cache is evicted and a broadcast is sent to all instances
+- Without Redis, invalidation uses PostgreSQL LISTEN/NOTIFY (all instances receive the notification in real time)
+- With Redis, invalidation uses Redis pub/sub (faster, more reliable in high-latency networks)
+
+### Login Rate Limiter
+
+The login endpoint (`POST /api/auth/login`) is protected by a rate limiter that prevents brute-force authentication attacks.
+
+**Default behavior (in-memory):**
+- Rate limit: 10 requests per 60-second window per client IP
+- Storage: In-memory; each instance has its own rate-limit counter
+- Suitable for: Single-instance deployments, development, testing
+
+**With Redis (shared state):**
+- Rate limit: 10 requests per 60-second window per client IP (same limit, shared across instances)
+- Storage: Redis; all backend instances query the same counter
+- Suitable for: Multi-replica deployments, load-balanced production setups
+
+### Redis Connection Details
 
 - **Startup validation**: The server pings Redis at startup to verify reachability. If the ping fails, the server logs an error and exits.
 - **Client IP detection**: The rate limiter uses the `X-Real-IP` header (set by reverse proxies like Nginx) to identify the client. Ensure your proxy sets this header correctly.
-- **Key isolation**: Rate-limit keys include the client IP to prevent one user's failed login attempts from blocking others.
+- **Key isolation**: Rate-limit and cache keys are namespaced to prevent collisions.
+- **Performance**: Redis is treated as an optimization layer. If Redis becomes unavailable after startup, the service continues to function with graceful degradation (in-process caching and PostgreSQL lookups).
 
 ### Example: Docker Compose with Redis
 
@@ -211,7 +254,7 @@ In production with multiple backend replicas behind a load balancer:
 
 1. **Configure Redis** to a shared instance (e.g., an AWS ElastiCache, Google Cloud Memorystore, or self-hosted Redis cluster)
 2. **Set Redis credentials** via `QUEUETI_REDIS_PASSWORD` and optionally `QUEUETI_REDIS_TLS_ENABLED`
-3. **Deploy replicas** — each instance connects to the same Redis and shares rate-limit state
+3. **Deploy replicas** — each instance connects to the same Redis for shared caching, broadcasting, and rate limiting
 4. **Security note**: Bind your Redis instance to a private network or use authentication and TLS (`QUEUETI_REDIS_TLS_ENABLED=true`) in production
 
 ## Delete Reaper Schedule

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -98,7 +98,7 @@ For production deployments with multiple queue-ti instances behind a load balanc
    - Login rate limiting (shared state across instances, prevents brute-force attacks)
    - Distributed caching (schema and topic config lookups avoid repeated DB round-trips)
    - Cross-instance broadcaster (schema and config changes invalidate caches immediately via Redis pub/sub)
-5. **PostgreSQL LISTEN/NOTIFY fallback** — Without Redis, changes to topic schemas or configurations are broadcast via PostgreSQL LISTEN/NOTIFY to all instances in real-time. This works but is less efficient for high-frequency changes.
+5. **PostgreSQL LISTEN/NOTIFY fallback** — Without Redis, schema and config changes are broadcast via PostgreSQL LISTEN/NOTIFY. This is fully functional for single-instance deployments; with multiple instances each maintains its own L1 cache with no shared L2.
 
 ### Example Kubernetes Deployment
 

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -94,8 +94,11 @@ For production deployments with multiple queue-ti instances behind a load balanc
 1. **Database** — Use a managed PostgreSQL service (AWS RDS, Google Cloud SQL, etc.) or a highly available PostgreSQL cluster
 2. **Load Balancer** — Place instances behind a load balancer for HTTP traffic (port 8080)
 3. **gRPC Routing** — For gRPC clients, use a gRPC-aware load balancer (e.g., Envoy, AWS NLB with gRPC support) or direct DNS to backend instances
-4. **Redis** — Configure a shared Redis instance for login rate limiting across all instances
-5. **Schema/Config Invalidation** — Changes to topic schemas or configurations are broadcast via PostgreSQL LISTEN/NOTIFY to all instances in real-time
+4. **Redis (recommended)** — Configure a shared Redis instance for:
+   - Login rate limiting (shared state across instances, prevents brute-force attacks)
+   - Distributed caching (schema and topic config lookups avoid repeated DB round-trips)
+   - Cross-instance broadcaster (schema and config changes invalidate caches immediately via Redis pub/sub)
+5. **PostgreSQL LISTEN/NOTIFY fallback** — Without Redis, changes to topic schemas or configurations are broadcast via PostgreSQL LISTEN/NOTIFY to all instances in real-time. This works but is less efficient for high-frequency changes.
 
 ### Example Kubernetes Deployment
 
@@ -141,6 +144,13 @@ spec:
           value: redis.default.svc.cluster.local
         - name: QUEUETI_REDIS_PORT
           value: "6379"
+        - name: QUEUETI_REDIS_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: queue-ti-redis
+              key: password
+        - name: QUEUETI_REDIS_TLS_ENABLED
+          value: "true"
         - name: QUEUETI_AUTH_ENABLED
           value: "true"
         - name: QUEUETI_AUTH_JWT_SECRET

--- a/docs/guide/schema-validation.md
+++ b/docs/guide/schema-validation.md
@@ -9,7 +9,7 @@ Topics can have an optional Avro schema registered. When a schema is registered 
 - **No schema = no validation**: Topics without a registered schema accept any payload. Existing messages are unaffected when a schema is added, updated, or removed.
 - **Performance**: Parsed Avro schemas are cached to eliminate repeated database lookups. Cache behavior depends on your Redis configuration:
   - **Without Redis**: Schemas are cached in-process (L1 only); invalidation uses PostgreSQL LISTEN/NOTIFY
-  - **With Redis**: Schemas are cached in two tiers — in-process (L1, ~microseconds) and Redis (L2, ~milliseconds) — shared across all instances; invalidation uses Redis pub/sub. Cache TTL is 30 seconds; "no schema" is also cached via a sentinel value to prevent repeated lookups for missing schemas.
+  - **With Redis**: Schemas are cached in two tiers — in-process (L1, ~microseconds) and Redis (L2, ~milliseconds) — shared across all instances with a 30-second TTL; invalidation uses Redis pub/sub. Topics with no registered schema are also cached via a sentinel to avoid repeated DB lookups.
 
 ## Validation Rules
 

--- a/docs/guide/schema-validation.md
+++ b/docs/guide/schema-validation.md
@@ -7,7 +7,9 @@ Topics can have an optional Avro schema registered. When a schema is registered 
 - **Schema registration**: Register an Avro schema for a topic via `PUT /api/topic-schemas/:topic`. The schema must be valid Avro JSON; invalid schemas are rejected with HTTP 400.
 - **Validation at enqueue**: When a message is enqueued to a topic with a schema, the payload is validated as JSON and checked against the schema structure. If the payload does not conform, the enqueue fails with HTTP 422.
 - **No schema = no validation**: Topics without a registered schema accept any payload. Existing messages are unaffected when a schema is added, updated, or removed.
-- **Performance**: Parsed Avro schemas are cached in memory per topic. The cache automatically invalidates when a schema is updated or deleted.
+- **Performance**: Parsed Avro schemas are cached to eliminate repeated database lookups. Cache behavior depends on your Redis configuration:
+  - **Without Redis**: Schemas are cached in-process (L1 only); invalidation uses PostgreSQL LISTEN/NOTIFY
+  - **With Redis**: Schemas are cached in two tiers — in-process (L1, ~microseconds) and Redis (L2, ~milliseconds) — shared across all instances; invalidation uses Redis pub/sub. Cache TTL is 30 seconds; "no schema" is also cached via a sentinel value to prevent repeated lookups for missing schemas.
 
 ## Validation Rules
 


### PR DESCRIPTION
Closes #19

## What

When Redis is enabled (existing `QUEUETI_REDIS_HOST` config), schema and topic config lookups are now backed by a distributed Redis cache in addition to the existing in-process caches. When Redis is not configured the behaviour is unchanged.

## Cache layers

**Schema (`queueti:cache:schema:<topic>`, TTL 30s)**
- L1: in-process `sync.Map` of compiled `avro.Schema` objects (existing)
- L2: Redis stores raw `TopicSchema` JSON — eliminates repeated DB round-trips on every `Enqueue` call
- Invalidated on `UpsertTopicSchemaAndNotify` / `DeleteTopicSchemaAndNotify` + broadcaster eviction

**Topic config (`queueti:cache:topic_config:<topic>`, TTL 30s)**
- L1: in-process `sync.Map` (`topicConfigEntry`) — new
- L2: Redis stores JSON-serialised `TopicConfig` — new
- Invalidated on `UpsertTopicConfig` / `DeleteTopicConfig` + broadcaster eviction
- "No config" cached as a sentinel to avoid repeated DB hits for unconfigured topics

## New package: `internal/cache`

- `Cache` interface: `Get / Set / Delete` with `context.Context` and TTL
- `Noop` implementation (default, zero-allocation)
- `Redis` implementation wrapping a narrow `Storage` interface — no fiber import in the cache layer; `Delete` loops per-key to match fiber's single-key signature

## Wiring

`NewService` defaults to `cache.Noop{}`. Call `queueService.UseCache(cache.NewRedis(store))` at startup to activate Redis (done in `cmd/server/main.go` when `cfg.Redis.Host != ""`).

## Tests

11 new BDD specs in `internal/queue/cache_test.go` using an in-memory `fakeCache` — no real Redis required. Cover hit/miss/invalidation for both caches.