### PR TITLE
ci: publish admin UI image to GHCR on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -305,6 +305,57 @@ jobs:
           cache-to: type=gha,mode=max
 
   # ─────────────────────────────────────────────────────────────────────────────
+  # Job 2b: Build & push admin UI Docker image to GHCR
+  # Runs in parallel with publish-image after the frontend gate passes.
+  # Same tag strategy as the backend image; uses ghcr.io/joessst-dev/queue-ti-ui.
+  # ─────────────────────────────────────────────────────────────────────────────
+  publish-ui-image:
+    name: "Docker: Build & push admin UI image"
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: [backend, frontend, node-client, python-client, go-client]
+
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate Docker metadata and tags
+        id: meta
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6.0.0
+        with:
+          images: ghcr.io/joessst-dev/queue-ti-ui
+          tags: |
+            type=raw,value=${{ github.ref_name }}
+            type=raw,value=preview,enable=${{ contains(github.ref_name, '-preview') }}
+            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-preview') && !contains(github.ref_name, '-rc') }}
+
+      - name: Build and push multi-arch admin UI image
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: ./ui
+          file: ./ui/Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=ui
+          cache-to: type=gha,mode=max,scope=ui
+
+  # ─────────────────────────────────────────────────────────────────────────────
   # Job 3: Publish @queue-ti/client to npm
   # Runs in parallel with publish-image after all gate jobs pass.
   # Version is derived from the CalVer tag (v2026.05.1 → 2026.5.1).
@@ -465,7 +516,7 @@ jobs:
     name: "GitHub: Create release"
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: [publish-image, publish-npm, publish-pypi]
+    needs: [publish-image, publish-ui-image, publish-npm, publish-pypi]
 
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -301,8 +301,8 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: BUILD_VERSION=${{ github.ref_name }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          cache-from: type=gha,scope=backend
+          cache-to: type=gha,mode=max,scope=backend
 
   # ─────────────────────────────────────────────────────────────────────────────
   # Job 2b: Build & push admin UI Docker image to GHCR

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -47,9 +47,7 @@ services:
         condition: service_healthy
 
   admin-ui:
-    build:
-      context: ./ui
-      dockerfile: Dockerfile
+    image: ghcr.io/joessst-dev/queue-ti-ui:latest
     ports:
       - "8081:80"
     depends_on:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -47,7 +47,9 @@ services:
         condition: service_healthy
 
   admin-ui:
-    image: ghcr.io/joessst-dev/queue-ti-ui:latest
+    build:
+      context: ./ui
+      dockerfile: Dockerfile
     ports:
       - "8081:80"
     depends_on:

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -2,9 +2,11 @@
 
 ## Docker
 
-### Pull the Latest Released Image
+### Pull the Latest Released Images
 
-The easiest way to run queue-ti is to pull a pre-built Docker image from GitHub Container Registry (GHCR). Releases are published automatically and include backend, admin UI, and all dependencies.
+Both the backend and the admin UI are published to GitHub Container Registry (GHCR) on every release.
+
+**Backend** (gRPC + HTTP API):
 
 ```bash
 # Latest stable release
@@ -12,6 +14,15 @@ docker pull ghcr.io/joessst-dev/queue-ti:latest
 
 # Or a specific version (e.g. v2026.05.0-preview.1)
 docker pull ghcr.io/joessst-dev/queue-ti:v2026.05.0-preview.1
+```
+
+**Admin UI** (Nginx serving the Angular SPA):
+
+```bash
+docker pull ghcr.io/joessst-dev/queue-ti-ui:latest
+
+# Or a specific version
+docker pull ghcr.io/joessst-dev/queue-ti-ui:v2026.05.0-preview.1
 ```
 
 ### Run with Docker
@@ -25,6 +36,9 @@ docker run -d \
   -e QUEUETI_DB_PASSWORD=postgres \
   -e QUEUETI_DB_NAME=queueti \
   ghcr.io/joessst-dev/queue-ti:latest
+
+# Admin UI (points to the backend at http://localhost:8080 by default)
+docker run -d -p 8081:80 ghcr.io/joessst-dev/queue-ti-ui:latest
 ```
 
 ### Build Locally from Source

--- a/docs/guide/deployment.md
+++ b/docs/guide/deployment.md
@@ -36,10 +36,9 @@ docker run -d \
   -e QUEUETI_DB_PASSWORD=postgres \
   -e QUEUETI_DB_NAME=queueti \
   ghcr.io/joessst-dev/queue-ti:latest
-
-# Admin UI (points to the backend at http://localhost:8080 by default)
-docker run -d -p 8081:80 ghcr.io/joessst-dev/queue-ti-ui:latest
 ```
+
+The admin UI image proxies API calls to the hostname `queueti` (the Docker Compose service name). It is designed to run alongside the backend via Docker Compose rather than as a standalone `docker run` container. Use the [Docker Compose](#docker-compose) setup below to run both together.
 
 ### Build Locally from Source
 


### PR DESCRIPTION
## Summary

- Adds `publish-ui-image` job to the release pipeline that builds and pushes `ghcr.io/joessst-dev/queue-ti-ui` (multi-arch: `linux/amd64` + `linux/arm64`) with the same tag strategy as the backend image (`exact`, `preview`, `latest`)
- `create-release` now waits for `publish-ui-image` in addition to the existing jobs
- `docker-compose.yaml` updated to pull `ghcr.io/joessst-dev/queue-ti-ui:latest` instead of building the UI from source each time
- Deployment docs updated to document both images and show the `docker run` command for each

## Test plan

- [ ] Verify release pipeline adds the `publish-ui-image` job and it runs in parallel with `publish-image`
- [ ] Confirm `ghcr.io/joessst-dev/queue-ti-ui` appears in GHCR after the next release tag
- [ ] `docker-compose up` pulls the published UI image successfully
- [ ] Admin UI is reachable at `http://localhost:8081` after `docker-compose up`