### PR TITLE
feat: admin client for Go, Node.js, and Python

### DIFF
--- a/clients/go-client/admin.go
+++ b/clients/go-client/admin.go
@@ -292,9 +292,9 @@ func (c *AdminClient) doRequest(ctx context.Context, method, url string, body an
 
 	switch resp.StatusCode {
 	case http.StatusNotFound:
-		return nil, fmt.Errorf("%w: %s %s", ErrNotFound, method, url)
+		return nil, fmt.Errorf("%w: %s %s: %s", ErrNotFound, method, url, string(rawBody))
 	case http.StatusConflict:
-		return nil, fmt.Errorf("%w: %s %s", ErrConflict, method, url)
+		return nil, fmt.Errorf("%w: %s %s: %s", ErrConflict, method, url, string(rawBody))
 	default:
 		return nil, fmt.Errorf("unexpected status %d from %s %s: %s", resp.StatusCode, method, url, string(rawBody))
 	}

--- a/clients/go-client/admin.go
+++ b/clients/go-client/admin.go
@@ -1,0 +1,301 @@
+package queueti
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// ErrNotFound is returned when the server responds with HTTP 404.
+var ErrNotFound = errors.New("not found")
+
+// ErrConflict is returned when the server responds with HTTP 409.
+var ErrConflict = errors.New("conflict")
+
+// TopicConfig holds the optional per-topic configuration that controls
+// delivery behaviour.
+type TopicConfig struct {
+	Topic               string `json:"topic"`
+	MaxRetries          *int   `json:"max_retries,omitempty"`
+	MessageTTLSeconds   *int   `json:"message_ttl_seconds,omitempty"`
+	MaxDepth            *int   `json:"max_depth,omitempty"`
+	Replayable          bool   `json:"replayable"`
+	ReplayWindowSeconds *int   `json:"replay_window_seconds,omitempty"`
+	ThroughputLimit     *int   `json:"throughput_limit,omitempty"`
+}
+
+// TopicSchema describes the Avro schema registered for a topic.
+type TopicSchema struct {
+	Topic      string `json:"topic"`
+	SchemaJSON string `json:"schema_json"`
+	Version    int    `json:"version"`
+	UpdatedAt  string `json:"updated_at"`
+}
+
+// TopicStat is a single row from the stats endpoint — one entry per
+// (topic, status) combination.
+type TopicStat struct {
+	Topic  string `json:"topic"`
+	Status string `json:"status"`
+	Count  int    `json:"count"`
+}
+
+// AdminClient calls the queue-ti HTTP admin API (port 8080).
+type AdminClient struct {
+	baseURL    string
+	httpClient *http.Client
+	token      string
+}
+
+// AdminOption configures an AdminClient.
+type AdminOption func(*AdminClient)
+
+// WithAdminToken sets the Bearer token sent in every request's
+// Authorization header. When empty, the header is omitted.
+func WithAdminToken(token string) AdminOption {
+	return func(c *AdminClient) {
+		c.token = token
+	}
+}
+
+// WithAdminHTTPClient replaces the default http.Client used for requests.
+func WithAdminHTTPClient(hc *http.Client) AdminOption {
+	return func(c *AdminClient) {
+		c.httpClient = hc
+	}
+}
+
+// NewAdminClient creates an AdminClient targeting baseURL.
+// baseURL should be the scheme+host+port only, e.g. "http://localhost:8080".
+func NewAdminClient(baseURL string, opts ...AdminOption) *AdminClient {
+	c := &AdminClient{
+		baseURL:    baseURL,
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+	}
+	for _, o := range opts {
+		o(c)
+	}
+	return c
+}
+
+// ---- Topic config ----------------------------------------------------------
+
+// ListTopicConfigs returns all topic configurations known to the server.
+func (c *AdminClient) ListTopicConfigs(ctx context.Context) ([]TopicConfig, error) {
+	resp, err := c.doRequest(ctx, http.MethodGet, c.baseURL+"/api/topic-configs", nil)
+	if err != nil {
+		return nil, fmt.Errorf("list topic configs: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var envelope struct {
+		Items []TopicConfig `json:"items"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		return nil, fmt.Errorf("list topic configs: decode response: %w", err)
+	}
+	return envelope.Items, nil
+}
+
+// UpsertTopicConfig creates or replaces the configuration for topic.
+func (c *AdminClient) UpsertTopicConfig(ctx context.Context, topic string, cfg TopicConfig) (*TopicConfig, error) {
+	resp, err := c.doRequest(ctx, http.MethodPut, c.baseURL+"/api/topic-configs/"+topic, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("upsert topic config %q: %w", topic, err)
+	}
+	defer resp.Body.Close()
+
+	var out TopicConfig
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("upsert topic config %q: decode response: %w", topic, err)
+	}
+	return &out, nil
+}
+
+// DeleteTopicConfig removes the configuration for topic.
+// Returns nil on HTTP 204.
+func (c *AdminClient) DeleteTopicConfig(ctx context.Context, topic string) error {
+	resp, err := c.doRequest(ctx, http.MethodDelete, c.baseURL+"/api/topic-configs/"+topic, nil)
+	if err != nil {
+		return fmt.Errorf("delete topic config %q: %w", topic, err)
+	}
+	resp.Body.Close()
+	return nil
+}
+
+// ---- Topic schema ----------------------------------------------------------
+
+// ListTopicSchemas returns all topic schemas registered on the server.
+func (c *AdminClient) ListTopicSchemas(ctx context.Context) ([]TopicSchema, error) {
+	resp, err := c.doRequest(ctx, http.MethodGet, c.baseURL+"/api/topic-schemas", nil)
+	if err != nil {
+		return nil, fmt.Errorf("list topic schemas: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var envelope struct {
+		Items []TopicSchema `json:"items"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		return nil, fmt.Errorf("list topic schemas: decode response: %w", err)
+	}
+	return envelope.Items, nil
+}
+
+// GetTopicSchema returns the registered schema for topic.
+// Returns ErrNotFound when no schema exists.
+func (c *AdminClient) GetTopicSchema(ctx context.Context, topic string) (*TopicSchema, error) {
+	resp, err := c.doRequest(ctx, http.MethodGet, c.baseURL+"/api/topic-schemas/"+topic, nil)
+	if err != nil {
+		return nil, fmt.Errorf("get topic schema %q: %w", topic, err)
+	}
+	defer resp.Body.Close()
+
+	var out TopicSchema
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("get topic schema %q: decode response: %w", topic, err)
+	}
+	return &out, nil
+}
+
+// UpsertTopicSchema creates or replaces the Avro schema for topic.
+func (c *AdminClient) UpsertTopicSchema(ctx context.Context, topic, schemaJSON string) (*TopicSchema, error) {
+	body := map[string]string{"schema_json": schemaJSON}
+	resp, err := c.doRequest(ctx, http.MethodPut, c.baseURL+"/api/topic-schemas/"+topic, body)
+	if err != nil {
+		return nil, fmt.Errorf("upsert topic schema %q: %w", topic, err)
+	}
+	defer resp.Body.Close()
+
+	var out TopicSchema
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("upsert topic schema %q: decode response: %w", topic, err)
+	}
+	return &out, nil
+}
+
+// DeleteTopicSchema removes the schema for topic.
+// Returns nil on HTTP 204.
+func (c *AdminClient) DeleteTopicSchema(ctx context.Context, topic string) error {
+	resp, err := c.doRequest(ctx, http.MethodDelete, c.baseURL+"/api/topic-schemas/"+topic, nil)
+	if err != nil {
+		return fmt.Errorf("delete topic schema %q: %w", topic, err)
+	}
+	resp.Body.Close()
+	return nil
+}
+
+// ---- Consumer groups -------------------------------------------------------
+
+// ListConsumerGroups returns the names of all consumer groups registered on topic.
+func (c *AdminClient) ListConsumerGroups(ctx context.Context, topic string) ([]string, error) {
+	resp, err := c.doRequest(ctx, http.MethodGet, c.baseURL+"/api/topics/"+topic+"/consumer-groups", nil)
+	if err != nil {
+		return nil, fmt.Errorf("list consumer groups for topic %q: %w", topic, err)
+	}
+	defer resp.Body.Close()
+
+	var envelope struct {
+		Items []string `json:"items"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		return nil, fmt.Errorf("list consumer groups for topic %q: decode response: %w", topic, err)
+	}
+	return envelope.Items, nil
+}
+
+// RegisterConsumerGroup creates a new consumer group on topic.
+// Returns ErrConflict when the group already exists.
+func (c *AdminClient) RegisterConsumerGroup(ctx context.Context, topic, group string) error {
+	body := map[string]string{"consumer_group": group}
+	resp, err := c.doRequest(ctx, http.MethodPost, c.baseURL+"/api/topics/"+topic+"/consumer-groups", body)
+	if err != nil {
+		return fmt.Errorf("register consumer group %q on topic %q: %w", group, topic, err)
+	}
+	resp.Body.Close()
+	return nil
+}
+
+// UnregisterConsumerGroup removes group from topic.
+// Returns ErrNotFound when the group does not exist.
+func (c *AdminClient) UnregisterConsumerGroup(ctx context.Context, topic, group string) error {
+	resp, err := c.doRequest(ctx, http.MethodDelete, c.baseURL+"/api/topics/"+topic+"/consumer-groups/"+group, nil)
+	if err != nil {
+		return fmt.Errorf("unregister consumer group %q on topic %q: %w", group, topic, err)
+	}
+	resp.Body.Close()
+	return nil
+}
+
+// ---- Stats -----------------------------------------------------------------
+
+// Stats returns per-topic message counts broken down by status.
+func (c *AdminClient) Stats(ctx context.Context) ([]TopicStat, error) {
+	resp, err := c.doRequest(ctx, http.MethodGet, c.baseURL+"/api/stats", nil)
+	if err != nil {
+		return nil, fmt.Errorf("stats: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var envelope struct {
+		Topics []TopicStat `json:"topics"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
+		return nil, fmt.Errorf("stats: decode response: %w", err)
+	}
+	return envelope.Topics, nil
+}
+
+// ---- Internal --------------------------------------------------------------
+
+// doRequest executes a single HTTP request. body is JSON-encoded when non-nil.
+// For non-2xx responses it reads the body and returns a descriptive error,
+// mapping 404 → ErrNotFound and 409 → ErrConflict.
+func (c *AdminClient) doRequest(ctx context.Context, method, url string, body any) (*http.Response, error) {
+	var bodyReader io.Reader
+	if body != nil {
+		encoded, err := json.Marshal(body)
+		if err != nil {
+			return nil, fmt.Errorf("marshal request body: %w", err)
+		}
+		bodyReader = bytes.NewReader(encoded)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, url, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("execute request: %w", err)
+	}
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return resp, nil
+	}
+
+	// Non-2xx — read the body for the error message then close.
+	rawBody, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusNotFound:
+		return nil, fmt.Errorf("%w: %s %s", ErrNotFound, method, url)
+	case http.StatusConflict:
+		return nil, fmt.Errorf("%w: %s %s", ErrConflict, method, url)
+	default:
+		return nil, fmt.Errorf("unexpected status %d from %s %s: %s", resp.StatusCode, method, url, string(rawBody))
+	}
+}

--- a/clients/go-client/admin.go
+++ b/clients/go-client/admin.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"time"
 )
 
@@ -104,7 +105,7 @@ func (c *AdminClient) ListTopicConfigs(ctx context.Context) ([]TopicConfig, erro
 
 // UpsertTopicConfig creates or replaces the configuration for topic.
 func (c *AdminClient) UpsertTopicConfig(ctx context.Context, topic string, cfg TopicConfig) (*TopicConfig, error) {
-	resp, err := c.doRequest(ctx, http.MethodPut, c.baseURL+"/api/topic-configs/"+topic, cfg)
+	resp, err := c.doRequest(ctx, http.MethodPut, c.baseURL+"/api/topic-configs/"+url.PathEscape(topic), cfg)
 	if err != nil {
 		return nil, fmt.Errorf("upsert topic config %q: %w", topic, err)
 	}
@@ -120,7 +121,7 @@ func (c *AdminClient) UpsertTopicConfig(ctx context.Context, topic string, cfg T
 // DeleteTopicConfig removes the configuration for topic.
 // Returns nil on HTTP 204.
 func (c *AdminClient) DeleteTopicConfig(ctx context.Context, topic string) error {
-	resp, err := c.doRequest(ctx, http.MethodDelete, c.baseURL+"/api/topic-configs/"+topic, nil)
+	resp, err := c.doRequest(ctx, http.MethodDelete, c.baseURL+"/api/topic-configs/"+url.PathEscape(topic), nil)
 	if err != nil {
 		return fmt.Errorf("delete topic config %q: %w", topic, err)
 	}
@@ -150,7 +151,7 @@ func (c *AdminClient) ListTopicSchemas(ctx context.Context) ([]TopicSchema, erro
 // GetTopicSchema returns the registered schema for topic.
 // Returns ErrNotFound when no schema exists.
 func (c *AdminClient) GetTopicSchema(ctx context.Context, topic string) (*TopicSchema, error) {
-	resp, err := c.doRequest(ctx, http.MethodGet, c.baseURL+"/api/topic-schemas/"+topic, nil)
+	resp, err := c.doRequest(ctx, http.MethodGet, c.baseURL+"/api/topic-schemas/"+url.PathEscape(topic), nil)
 	if err != nil {
 		return nil, fmt.Errorf("get topic schema %q: %w", topic, err)
 	}
@@ -166,7 +167,7 @@ func (c *AdminClient) GetTopicSchema(ctx context.Context, topic string) (*TopicS
 // UpsertTopicSchema creates or replaces the Avro schema for topic.
 func (c *AdminClient) UpsertTopicSchema(ctx context.Context, topic, schemaJSON string) (*TopicSchema, error) {
 	body := map[string]string{"schema_json": schemaJSON}
-	resp, err := c.doRequest(ctx, http.MethodPut, c.baseURL+"/api/topic-schemas/"+topic, body)
+	resp, err := c.doRequest(ctx, http.MethodPut, c.baseURL+"/api/topic-schemas/"+url.PathEscape(topic), body)
 	if err != nil {
 		return nil, fmt.Errorf("upsert topic schema %q: %w", topic, err)
 	}
@@ -182,7 +183,7 @@ func (c *AdminClient) UpsertTopicSchema(ctx context.Context, topic, schemaJSON s
 // DeleteTopicSchema removes the schema for topic.
 // Returns nil on HTTP 204.
 func (c *AdminClient) DeleteTopicSchema(ctx context.Context, topic string) error {
-	resp, err := c.doRequest(ctx, http.MethodDelete, c.baseURL+"/api/topic-schemas/"+topic, nil)
+	resp, err := c.doRequest(ctx, http.MethodDelete, c.baseURL+"/api/topic-schemas/"+url.PathEscape(topic), nil)
 	if err != nil {
 		return fmt.Errorf("delete topic schema %q: %w", topic, err)
 	}
@@ -194,7 +195,7 @@ func (c *AdminClient) DeleteTopicSchema(ctx context.Context, topic string) error
 
 // ListConsumerGroups returns the names of all consumer groups registered on topic.
 func (c *AdminClient) ListConsumerGroups(ctx context.Context, topic string) ([]string, error) {
-	resp, err := c.doRequest(ctx, http.MethodGet, c.baseURL+"/api/topics/"+topic+"/consumer-groups", nil)
+	resp, err := c.doRequest(ctx, http.MethodGet, c.baseURL+"/api/topics/"+url.PathEscape(topic)+"/consumer-groups", nil)
 	if err != nil {
 		return nil, fmt.Errorf("list consumer groups for topic %q: %w", topic, err)
 	}
@@ -213,7 +214,7 @@ func (c *AdminClient) ListConsumerGroups(ctx context.Context, topic string) ([]s
 // Returns ErrConflict when the group already exists.
 func (c *AdminClient) RegisterConsumerGroup(ctx context.Context, topic, group string) error {
 	body := map[string]string{"consumer_group": group}
-	resp, err := c.doRequest(ctx, http.MethodPost, c.baseURL+"/api/topics/"+topic+"/consumer-groups", body)
+	resp, err := c.doRequest(ctx, http.MethodPost, c.baseURL+"/api/topics/"+url.PathEscape(topic)+"/consumer-groups", body)
 	if err != nil {
 		return fmt.Errorf("register consumer group %q on topic %q: %w", group, topic, err)
 	}
@@ -224,7 +225,7 @@ func (c *AdminClient) RegisterConsumerGroup(ctx context.Context, topic, group st
 // UnregisterConsumerGroup removes group from topic.
 // Returns ErrNotFound when the group does not exist.
 func (c *AdminClient) UnregisterConsumerGroup(ctx context.Context, topic, group string) error {
-	resp, err := c.doRequest(ctx, http.MethodDelete, c.baseURL+"/api/topics/"+topic+"/consumer-groups/"+group, nil)
+	resp, err := c.doRequest(ctx, http.MethodDelete, c.baseURL+"/api/topics/"+url.PathEscape(topic)+"/consumer-groups/"+url.PathEscape(group), nil)
 	if err != nil {
 		return fmt.Errorf("unregister consumer group %q on topic %q: %w", group, topic, err)
 	}

--- a/clients/go-client/admin_test.go
+++ b/clients/go-client/admin_test.go
@@ -1,0 +1,450 @@
+package queueti_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+
+	queueti "github.com/Joessst-Dev/queue-ti/clients/go-client"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// adminFakeServer captures incoming requests and serves canned JSON responses.
+type adminFakeServer struct {
+	mu           sync.Mutex
+	requests     []*http.Request
+	rawBodies    [][]byte
+	statusCode   int
+	responseBody []byte
+}
+
+func (f *adminFakeServer) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		f.mu.Lock()
+		defer f.mu.Unlock()
+
+		// Snapshot the request body before the handler returns.
+		var raw []byte
+		if r.Body != nil {
+			if err := json.NewDecoder(r.Body).Decode(new(json.RawMessage)); err == nil {
+				// Re-read for recording: parse into generic map then re-encode.
+			}
+			r.Body.Close()
+		}
+		// Simpler: just store a clone of the decoded body separately.
+		f.requests = append(f.requests, r)
+		f.rawBodies = append(f.rawBodies, raw)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(f.statusCode)
+		_, _ = w.Write(f.responseBody)
+	}
+}
+
+
+// newFake builds an httptest.Server with canned status + body.
+// The caller is responsible for calling ts.Close().
+func newFake(statusCode int, body []byte) (*adminFakeServer, *httptest.Server) {
+	f := &adminFakeServer{statusCode: statusCode, responseBody: body}
+	ts := httptest.NewServer(f.handler())
+	return f, ts
+}
+
+// captureBodyServer records the raw request body in addition to headers.
+type captureBodyServer struct {
+	mu         sync.Mutex
+	requests   []*capturedRequest
+	statusCode int
+	respBody   []byte
+}
+
+type capturedRequest struct {
+	method string
+	path   string
+	header http.Header
+	body   map[string]any
+}
+
+func (s *captureBodyServer) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		cr := &capturedRequest{
+			method: r.Method,
+			path:   r.URL.Path,
+			header: r.Header.Clone(),
+		}
+		if r.Body != nil {
+			defer r.Body.Close()
+			var m map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&m); err == nil {
+				cr.body = m
+			}
+		}
+		s.mu.Lock()
+		s.requests = append(s.requests, cr)
+		s.mu.Unlock()
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(s.statusCode)
+		_, _ = w.Write(s.respBody)
+	}
+}
+
+func (s *captureBodyServer) last() *capturedRequest {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.requests) == 0 {
+		return nil
+	}
+	return s.requests[len(s.requests)-1]
+}
+
+func newCapture(statusCode int, body []byte) (*captureBodyServer, *httptest.Server) {
+	s := &captureBodyServer{statusCode: statusCode, respBody: body}
+	ts := httptest.NewServer(s.handler())
+	return s, ts
+}
+
+// intPtr is a convenience helper for taking the address of an int literal.
+func intPtr(v int) *int { return &v }
+
+var _ = Describe("AdminClient", func() {
+	var ctx context.Context
+
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+
+	// ---- Topic config -------------------------------------------------------
+
+	Describe("ListTopicConfigs", func() {
+		Context("when the server returns a list of configs", func() {
+			It("returns the items array", func() {
+				body := []byte(`{"items":[{"topic":"orders","replayable":true},{"topic":"payments","replayable":false}]}`)
+				_, ts := newFake(http.StatusOK, body)
+				defer ts.Close()
+
+				client := queueti.NewAdminClient(ts.URL, queueti.WithAdminToken("secret"))
+				configs, err := client.ListTopicConfigs(ctx)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(configs).To(HaveLen(2))
+				Expect(configs[0].Topic).To(Equal("orders"))
+				Expect(configs[0].Replayable).To(BeTrue())
+				Expect(configs[1].Topic).To(Equal("payments"))
+			})
+		})
+
+		Context("when the server returns an empty list", func() {
+			It("returns an empty (not nil) slice", func() {
+				body := []byte(`{"items":[]}`)
+				_, ts := newFake(http.StatusOK, body)
+				defer ts.Close()
+
+				client := queueti.NewAdminClient(ts.URL)
+				configs, err := client.ListTopicConfigs(ctx)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(configs).To(BeEmpty())
+			})
+		})
+	})
+
+	Describe("UpsertTopicConfig", func() {
+		Context("when the server accepts the config", func() {
+			It("sends a PUT with the correct body and returns the saved config", func() {
+				responseBody := []byte(`{"topic":"orders","max_retries":5,"replayable":true}`)
+				srv, ts := newCapture(http.StatusOK, responseBody)
+				defer ts.Close()
+
+				client := queueti.NewAdminClient(ts.URL, queueti.WithAdminToken("tok"))
+				cfg := queueti.TopicConfig{
+					Topic:      "orders",
+					MaxRetries: intPtr(5),
+					Replayable: true,
+				}
+				result, err := client.UpsertTopicConfig(ctx, "orders", cfg)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.Topic).To(Equal("orders"))
+				Expect(result.MaxRetries).NotTo(BeNil())
+				Expect(*result.MaxRetries).To(Equal(5))
+				Expect(result.Replayable).To(BeTrue())
+
+				req := srv.last()
+				Expect(req.method).To(Equal(http.MethodPut))
+				Expect(req.path).To(Equal("/api/topic-configs/orders"))
+				Expect(req.header.Get("Authorization")).To(Equal("Bearer tok"))
+				Expect(req.body).To(HaveKey("topic"))
+			})
+		})
+	})
+
+	Describe("DeleteTopicConfig", func() {
+		Context("when the server acknowledges the deletion", func() {
+			It("sends DELETE and returns nil on 204", func() {
+				srv, ts := newCapture(http.StatusNoContent, nil)
+				defer ts.Close()
+
+				client := queueti.NewAdminClient(ts.URL)
+				err := client.DeleteTopicConfig(ctx, "orders")
+
+				Expect(err).NotTo(HaveOccurred())
+				req := srv.last()
+				Expect(req.method).To(Equal(http.MethodDelete))
+				Expect(req.path).To(Equal("/api/topic-configs/orders"))
+			})
+		})
+	})
+
+	// ---- Topic schema -------------------------------------------------------
+
+	Describe("ListTopicSchemas", func() {
+		Context("when the server returns schemas", func() {
+			It("returns the items array", func() {
+				body := []byte(`{"items":[{"topic":"orders","schema_json":"{}","version":1,"updated_at":"2024-01-01T00:00:00Z"}]}`)
+				_, ts := newFake(http.StatusOK, body)
+				defer ts.Close()
+
+				client := queueti.NewAdminClient(ts.URL)
+				schemas, err := client.ListTopicSchemas(ctx)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(schemas).To(HaveLen(1))
+				Expect(schemas[0].Topic).To(Equal("orders"))
+				Expect(schemas[0].Version).To(Equal(1))
+			})
+		})
+	})
+
+	Describe("GetTopicSchema", func() {
+		Context("when the schema exists", func() {
+			It("returns the schema for the requested topic", func() {
+				body := []byte(`{"topic":"orders","schema_json":"{\"type\":\"record\"}","version":2,"updated_at":"2024-06-01T00:00:00Z"}`)
+				_, ts := newFake(http.StatusOK, body)
+				defer ts.Close()
+
+				client := queueti.NewAdminClient(ts.URL)
+				schema, err := client.GetTopicSchema(ctx, "orders")
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(schema.Topic).To(Equal("orders"))
+				Expect(schema.Version).To(Equal(2))
+			})
+		})
+
+		Context("when the schema does not exist", func() {
+			It("returns ErrNotFound", func() {
+				_, ts := newFake(http.StatusNotFound, []byte(`{"error":"not found"}`))
+				defer ts.Close()
+
+				client := queueti.NewAdminClient(ts.URL)
+				_, err := client.GetTopicSchema(ctx, "unknown")
+
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(ContainSubstring("not found")))
+				Expect(isNotFound(err)).To(BeTrue())
+			})
+		})
+	})
+
+	Describe("UpsertTopicSchema", func() {
+		Context("when the server accepts the schema", func() {
+			It("sends the schema_json body and returns the saved schema", func() {
+				responseBody := []byte(`{"topic":"orders","schema_json":"{\"type\":\"record\"}","version":1,"updated_at":"2024-01-01T00:00:00Z"}`)
+				srv, ts := newCapture(http.StatusOK, responseBody)
+				defer ts.Close()
+
+				client := queueti.NewAdminClient(ts.URL, queueti.WithAdminToken("admin"))
+				schema, err := client.UpsertTopicSchema(ctx, "orders", `{"type":"record"}`)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(schema.Topic).To(Equal("orders"))
+
+				req := srv.last()
+				Expect(req.method).To(Equal(http.MethodPut))
+				Expect(req.path).To(Equal("/api/topic-schemas/orders"))
+				Expect(req.body).To(HaveKeyWithValue("schema_json", `{"type":"record"}`))
+			})
+		})
+	})
+
+	Describe("DeleteTopicSchema", func() {
+		Context("when the server acknowledges the deletion", func() {
+			It("sends DELETE and returns nil on 204", func() {
+				srv, ts := newCapture(http.StatusNoContent, nil)
+				defer ts.Close()
+
+				client := queueti.NewAdminClient(ts.URL)
+				err := client.DeleteTopicSchema(ctx, "orders")
+
+				Expect(err).NotTo(HaveOccurred())
+				req := srv.last()
+				Expect(req.method).To(Equal(http.MethodDelete))
+				Expect(req.path).To(Equal("/api/topic-schemas/orders"))
+			})
+		})
+	})
+
+	// ---- Consumer groups ----------------------------------------------------
+
+	Describe("ListConsumerGroups", func() {
+		Context("when consumer groups exist for the topic", func() {
+			It("returns the items array", func() {
+				body := []byte(`{"items":["billing","analytics"]}`)
+				_, ts := newFake(http.StatusOK, body)
+				defer ts.Close()
+
+				client := queueti.NewAdminClient(ts.URL)
+				groups, err := client.ListConsumerGroups(ctx, "orders")
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(groups).To(ConsistOf("billing", "analytics"))
+			})
+		})
+	})
+
+	Describe("RegisterConsumerGroup", func() {
+		Context("when the group does not yet exist", func() {
+			It("sends POST with the correct body and returns nil on 201", func() {
+				srv, ts := newCapture(http.StatusCreated, []byte(`{}`))
+				defer ts.Close()
+
+				client := queueti.NewAdminClient(ts.URL, queueti.WithAdminToken("tok"))
+				err := client.RegisterConsumerGroup(ctx, "orders", "billing")
+
+				Expect(err).NotTo(HaveOccurred())
+				req := srv.last()
+				Expect(req.method).To(Equal(http.MethodPost))
+				Expect(req.path).To(Equal("/api/topics/orders/consumer-groups"))
+				Expect(req.body).To(HaveKeyWithValue("consumer_group", "billing"))
+				Expect(req.header.Get("Authorization")).To(Equal("Bearer tok"))
+			})
+		})
+
+		Context("when the group already exists", func() {
+			It("returns ErrConflict", func() {
+				_, ts := newFake(http.StatusConflict, []byte(`{"error":"already exists"}`))
+				defer ts.Close()
+
+				client := queueti.NewAdminClient(ts.URL)
+				err := client.RegisterConsumerGroup(ctx, "orders", "billing")
+
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(ContainSubstring("conflict")))
+				Expect(isConflict(err)).To(BeTrue())
+			})
+		})
+	})
+
+	Describe("UnregisterConsumerGroup", func() {
+		Context("when the group exists", func() {
+			It("sends DELETE and returns nil on 204", func() {
+				srv, ts := newCapture(http.StatusNoContent, nil)
+				defer ts.Close()
+
+				client := queueti.NewAdminClient(ts.URL)
+				err := client.UnregisterConsumerGroup(ctx, "orders", "billing")
+
+				Expect(err).NotTo(HaveOccurred())
+				req := srv.last()
+				Expect(req.method).To(Equal(http.MethodDelete))
+				Expect(req.path).To(Equal("/api/topics/orders/consumer-groups/billing"))
+			})
+		})
+
+		Context("when the group does not exist", func() {
+			It("returns ErrNotFound", func() {
+				_, ts := newFake(http.StatusNotFound, []byte(`{"error":"not found"}`))
+				defer ts.Close()
+
+				client := queueti.NewAdminClient(ts.URL)
+				err := client.UnregisterConsumerGroup(ctx, "orders", "ghost")
+
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(ContainSubstring("not found")))
+				Expect(isNotFound(err)).To(BeTrue())
+			})
+		})
+	})
+
+	// ---- Stats --------------------------------------------------------------
+
+	Describe("Stats", func() {
+		Context("when the server returns topic statistics", func() {
+			It("returns the topics array", func() {
+				body := []byte(`{"topics":[{"topic":"orders","status":"pending","count":42},{"topic":"orders","status":"acked","count":7}]}`)
+				_, ts := newFake(http.StatusOK, body)
+				defer ts.Close()
+
+				client := queueti.NewAdminClient(ts.URL)
+				stats, err := client.Stats(ctx)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(stats).To(HaveLen(2))
+				Expect(stats[0].Topic).To(Equal("orders"))
+				Expect(stats[0].Status).To(Equal("pending"))
+				Expect(stats[0].Count).To(Equal(42))
+				Expect(stats[1].Status).To(Equal("acked"))
+				Expect(stats[1].Count).To(Equal(7))
+			})
+		})
+	})
+
+	// ---- Options ------------------------------------------------------------
+
+	Describe("WithAdminHTTPClient", func() {
+		It("uses the provided http.Client for requests", func() {
+			body := []byte(`{"topics":[{"topic":"orders","status":"pending","count":1}]}`)
+			srv, ts := newCapture(http.StatusOK, body)
+			defer ts.Close()
+
+			// Verify that our injected client is the one that hits the server by
+			// wrapping the default transport and asserting the request arrived.
+			customClient := &http.Client{Transport: http.DefaultTransport}
+			client := queueti.NewAdminClient(ts.URL, queueti.WithAdminHTTPClient(customClient))
+			stats, err := client.Stats(ctx)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(stats).To(HaveLen(1))
+			Expect(srv.last()).NotTo(BeNil())
+		})
+	})
+})
+
+// isNotFound reports whether err wraps queueti.ErrNotFound.
+func isNotFound(err error) bool {
+	target := queueti.ErrNotFound
+	for err != nil {
+		if err == target {
+			return true
+		}
+		type unwrapper interface{ Unwrap() error }
+		if u, ok := err.(unwrapper); ok {
+			err = u.Unwrap()
+		} else {
+			return false
+		}
+	}
+	return false
+}
+
+// isConflict reports whether err wraps queueti.ErrConflict.
+func isConflict(err error) bool {
+	target := queueti.ErrConflict
+	for err != nil {
+		if err == target {
+			return true
+		}
+		type unwrapper interface{ Unwrap() error }
+		if u, ok := err.(unwrapper); ok {
+			err = u.Unwrap()
+		} else {
+			return false
+		}
+	}
+	return false
+}

--- a/clients/go-client/admin_test.go
+++ b/clients/go-client/admin_test.go
@@ -14,45 +14,14 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-// adminFakeServer captures incoming requests and serves canned JSON responses.
-type adminFakeServer struct {
-	mu           sync.Mutex
-	requests     []*http.Request
-	rawBodies    [][]byte
-	statusCode   int
-	responseBody []byte
-}
-
-func (f *adminFakeServer) handler() http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		f.mu.Lock()
-		defer f.mu.Unlock()
-
-		// Snapshot the request body before the handler returns.
-		var raw []byte
-		if r.Body != nil {
-			if err := json.NewDecoder(r.Body).Decode(new(json.RawMessage)); err == nil {
-				// Re-read for recording: parse into generic map then re-encode.
-			}
-			r.Body.Close()
-		}
-		// Simpler: just store a clone of the decoded body separately.
-		f.requests = append(f.requests, r)
-		f.rawBodies = append(f.rawBodies, raw)
-
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(f.statusCode)
-		_, _ = w.Write(f.responseBody)
-	}
-}
-
-
-// newFake builds an httptest.Server with canned status + body.
+// newFake builds an httptest.Server that always responds with statusCode and body.
 // The caller is responsible for calling ts.Close().
-func newFake(statusCode int, body []byte) (*adminFakeServer, *httptest.Server) {
-	f := &adminFakeServer{statusCode: statusCode, responseBody: body}
-	ts := httptest.NewServer(f.handler())
-	return f, ts
+func newFake(statusCode int, body []byte) *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(statusCode)
+		_, _ = w.Write(body)
+	}))
 }
 
 // captureBodyServer records the raw request body in addition to headers.
@@ -125,7 +94,7 @@ var _ = Describe("AdminClient", func() {
 		Context("when the server returns a list of configs", func() {
 			It("returns the items array", func() {
 				body := []byte(`{"items":[{"topic":"orders","replayable":true},{"topic":"payments","replayable":false}]}`)
-				_, ts := newFake(http.StatusOK, body)
+				ts := newFake(http.StatusOK, body)
 				defer ts.Close()
 
 				client := queueti.NewAdminClient(ts.URL, queueti.WithAdminToken("secret"))
@@ -142,7 +111,7 @@ var _ = Describe("AdminClient", func() {
 		Context("when the server returns an empty list", func() {
 			It("returns an empty (not nil) slice", func() {
 				body := []byte(`{"items":[]}`)
-				_, ts := newFake(http.StatusOK, body)
+				ts := newFake(http.StatusOK, body)
 				defer ts.Close()
 
 				client := queueti.NewAdminClient(ts.URL)
@@ -207,7 +176,7 @@ var _ = Describe("AdminClient", func() {
 		Context("when the server returns schemas", func() {
 			It("returns the items array", func() {
 				body := []byte(`{"items":[{"topic":"orders","schema_json":"{}","version":1,"updated_at":"2024-01-01T00:00:00Z"}]}`)
-				_, ts := newFake(http.StatusOK, body)
+				ts := newFake(http.StatusOK, body)
 				defer ts.Close()
 
 				client := queueti.NewAdminClient(ts.URL)
@@ -225,7 +194,7 @@ var _ = Describe("AdminClient", func() {
 		Context("when the schema exists", func() {
 			It("returns the schema for the requested topic", func() {
 				body := []byte(`{"topic":"orders","schema_json":"{\"type\":\"record\"}","version":2,"updated_at":"2024-06-01T00:00:00Z"}`)
-				_, ts := newFake(http.StatusOK, body)
+				ts := newFake(http.StatusOK, body)
 				defer ts.Close()
 
 				client := queueti.NewAdminClient(ts.URL)
@@ -239,7 +208,7 @@ var _ = Describe("AdminClient", func() {
 
 		Context("when the schema does not exist", func() {
 			It("returns ErrNotFound", func() {
-				_, ts := newFake(http.StatusNotFound, []byte(`{"error":"not found"}`))
+				ts := newFake(http.StatusNotFound, []byte(`{"error":"not found"}`))
 				defer ts.Close()
 
 				client := queueti.NewAdminClient(ts.URL)
@@ -296,7 +265,7 @@ var _ = Describe("AdminClient", func() {
 		Context("when consumer groups exist for the topic", func() {
 			It("returns the items array", func() {
 				body := []byte(`{"items":["billing","analytics"]}`)
-				_, ts := newFake(http.StatusOK, body)
+				ts := newFake(http.StatusOK, body)
 				defer ts.Close()
 
 				client := queueti.NewAdminClient(ts.URL)
@@ -328,7 +297,7 @@ var _ = Describe("AdminClient", func() {
 
 		Context("when the group already exists", func() {
 			It("returns ErrConflict", func() {
-				_, ts := newFake(http.StatusConflict, []byte(`{"error":"already exists"}`))
+				ts := newFake(http.StatusConflict, []byte(`{"error":"already exists"}`))
 				defer ts.Close()
 
 				client := queueti.NewAdminClient(ts.URL)
@@ -359,7 +328,7 @@ var _ = Describe("AdminClient", func() {
 
 		Context("when the group does not exist", func() {
 			It("returns ErrNotFound", func() {
-				_, ts := newFake(http.StatusNotFound, []byte(`{"error":"not found"}`))
+				ts := newFake(http.StatusNotFound, []byte(`{"error":"not found"}`))
 				defer ts.Close()
 
 				client := queueti.NewAdminClient(ts.URL)
@@ -378,7 +347,7 @@ var _ = Describe("AdminClient", func() {
 		Context("when the server returns topic statistics", func() {
 			It("returns the topics array", func() {
 				body := []byte(`{"topics":[{"topic":"orders","status":"pending","count":42},{"topic":"orders","status":"acked","count":7}]}`)
-				_, ts := newFake(http.StatusOK, body)
+				ts := newFake(http.StatusOK, body)
 				defer ts.Close()
 
 				client := queueti.NewAdminClient(ts.URL)

--- a/clients/go-client/admin_test.go
+++ b/clients/go-client/admin_test.go
@@ -3,6 +3,7 @@ package queueti_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -246,7 +247,7 @@ var _ = Describe("AdminClient", func() {
 
 				Expect(err).To(HaveOccurred())
 				Expect(err).To(MatchError(ContainSubstring("not found")))
-				Expect(isNotFound(err)).To(BeTrue())
+				Expect(errors.Is(err, queueti.ErrNotFound)).To(BeTrue())
 			})
 		})
 	})
@@ -335,7 +336,7 @@ var _ = Describe("AdminClient", func() {
 
 				Expect(err).To(HaveOccurred())
 				Expect(err).To(MatchError(ContainSubstring("conflict")))
-				Expect(isConflict(err)).To(BeTrue())
+				Expect(errors.Is(err, queueti.ErrConflict)).To(BeTrue())
 			})
 		})
 	})
@@ -366,7 +367,7 @@ var _ = Describe("AdminClient", func() {
 
 				Expect(err).To(HaveOccurred())
 				Expect(err).To(MatchError(ContainSubstring("not found")))
-				Expect(isNotFound(err)).To(BeTrue())
+				Expect(errors.Is(err, queueti.ErrNotFound)).To(BeTrue())
 			})
 		})
 	})
@@ -415,36 +416,3 @@ var _ = Describe("AdminClient", func() {
 	})
 })
 
-// isNotFound reports whether err wraps queueti.ErrNotFound.
-func isNotFound(err error) bool {
-	target := queueti.ErrNotFound
-	for err != nil {
-		if err == target {
-			return true
-		}
-		type unwrapper interface{ Unwrap() error }
-		if u, ok := err.(unwrapper); ok {
-			err = u.Unwrap()
-		} else {
-			return false
-		}
-	}
-	return false
-}
-
-// isConflict reports whether err wraps queueti.ErrConflict.
-func isConflict(err error) bool {
-	target := queueti.ErrConflict
-	for err != nil {
-		if err == target {
-			return true
-		}
-		type unwrapper interface{ Unwrap() error }
-		if u, ok := err.(unwrapper); ok {
-			err = u.Unwrap()
-		} else {
-			return false
-		}
-	}
-	return false
-}

--- a/clients/node/src/__tests__/admin.spec.ts
+++ b/clients/node/src/__tests__/admin.spec.ts
@@ -1,0 +1,312 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { AdminClient, AdminError } from '../admin'
+
+const BASE_URL = 'http://localhost:8080'
+
+function makeFetch(status: number, body: unknown): ReturnType<typeof vi.fn> {
+  return vi.fn().mockResolvedValue({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: 'OK',
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(''),
+  })
+}
+
+function makeClient(token?: string): AdminClient {
+  return new AdminClient(BASE_URL, token ? { token } : undefined)
+}
+
+describe('AdminClient', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  describe('listTopicConfigs()', () => {
+    describe('when the server returns a list of configs', () => {
+      it('should return the items array', async () => {
+        const items = [{ topic: 'orders', replayable: false }]
+        vi.stubGlobal('fetch', makeFetch(200, { items }))
+
+        const client = makeClient()
+        const result = await client.listTopicConfigs()
+
+        expect(result).toEqual(items)
+      })
+
+      it('should send a GET request to /api/topic-configs', async () => {
+        const mockFetch = makeFetch(200, { items: [] })
+        vi.stubGlobal('fetch', mockFetch)
+
+        await makeClient().listTopicConfigs()
+
+        expect(mockFetch).toHaveBeenCalledWith(
+          `${BASE_URL}/api/topic-configs`,
+          expect.objectContaining({ method: 'GET' }),
+        )
+      })
+
+      it('should include the Authorization header when a token is set', async () => {
+        const mockFetch = makeFetch(200, { items: [] })
+        vi.stubGlobal('fetch', mockFetch)
+
+        await makeClient('secret-token').listTopicConfigs()
+
+        expect(mockFetch).toHaveBeenCalledWith(
+          expect.any(String),
+          expect.objectContaining({
+            headers: expect.objectContaining({ Authorization: 'Bearer secret-token' }),
+          }),
+        )
+      })
+    })
+  })
+
+  describe('upsertTopicConfig()', () => {
+    describe('when the server accepts the config', () => {
+      it('should send a PUT request with the JSON body', async () => {
+        const returned = { topic: 'orders', replayable: true, max_retries: 3 }
+        const mockFetch = makeFetch(200, returned)
+        vi.stubGlobal('fetch', mockFetch)
+
+        const input = { replayable: true, max_retries: 3 }
+        const result = await makeClient().upsertTopicConfig('orders', input)
+
+        expect(result).toEqual(returned)
+        expect(mockFetch).toHaveBeenCalledWith(
+          `${BASE_URL}/api/topic-configs/orders`,
+          expect.objectContaining({
+            method: 'PUT',
+            body: JSON.stringify(input),
+            headers: expect.objectContaining({ 'Content-Type': 'application/json' }),
+          }),
+        )
+      })
+    })
+  })
+
+  describe('deleteTopicConfig()', () => {
+    describe('when the server responds with 204', () => {
+      it('should resolve void', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+          ok: true,
+          status: 204,
+          statusText: 'No Content',
+          json: () => Promise.resolve(null),
+          text: () => Promise.resolve(''),
+        }))
+
+        await expect(makeClient().deleteTopicConfig('orders')).resolves.toBeUndefined()
+      })
+
+      it('should send a DELETE request to the correct path', async () => {
+        const mockFetch = vi.fn().mockResolvedValue({
+          ok: true,
+          status: 204,
+          statusText: 'No Content',
+          json: () => Promise.resolve(null),
+          text: () => Promise.resolve(''),
+        })
+        vi.stubGlobal('fetch', mockFetch)
+
+        await makeClient().deleteTopicConfig('orders')
+
+        expect(mockFetch).toHaveBeenCalledWith(
+          `${BASE_URL}/api/topic-configs/orders`,
+          expect.objectContaining({ method: 'DELETE' }),
+        )
+      })
+    })
+  })
+
+  describe('getTopicSchema()', () => {
+    describe('when the schema exists', () => {
+      it('should return the schema', async () => {
+        const schema = { topic: 'orders', schema_json: '{}', version: 1, updated_at: '2024-01-01T00:00:00Z' }
+        vi.stubGlobal('fetch', makeFetch(200, schema))
+
+        const result = await makeClient().getTopicSchema('orders')
+
+        expect(result).toEqual(schema)
+      })
+    })
+
+    describe('when the server returns 404', () => {
+      it('should throw AdminError with statusCode 404', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+          ok: false,
+          status: 404,
+          statusText: 'Not Found',
+          json: () => Promise.resolve(null),
+          text: () => Promise.resolve('not found'),
+        }))
+
+        await expect(makeClient().getTopicSchema('missing')).rejects.toSatisfy(
+          (err: unknown) => err instanceof AdminError && err.statusCode === 404,
+        )
+      })
+    })
+  })
+
+  describe('upsertTopicSchema()', () => {
+    describe('when the server accepts the schema', () => {
+      it('should send schema_json in the request body', async () => {
+        const returned = { topic: 'orders', schema_json: '{"type":"record"}', version: 2, updated_at: '2024-01-01T00:00:00Z' }
+        const mockFetch = makeFetch(200, returned)
+        vi.stubGlobal('fetch', mockFetch)
+
+        const result = await makeClient().upsertTopicSchema('orders', '{"type":"record"}')
+
+        expect(result).toEqual(returned)
+        expect(mockFetch).toHaveBeenCalledWith(
+          `${BASE_URL}/api/topic-schemas/orders`,
+          expect.objectContaining({
+            method: 'PUT',
+            body: JSON.stringify({ schema_json: '{"type":"record"}' }),
+          }),
+        )
+      })
+    })
+  })
+
+  describe('listConsumerGroups()', () => {
+    describe('when the server returns a list of groups', () => {
+      it('should return the items array', async () => {
+        const items = ['group-a', 'group-b']
+        vi.stubGlobal('fetch', makeFetch(200, { items }))
+
+        const result = await makeClient().listConsumerGroups('orders')
+
+        expect(result).toEqual(items)
+      })
+
+      it('should call the correct endpoint for the topic', async () => {
+        const mockFetch = makeFetch(200, { items: [] })
+        vi.stubGlobal('fetch', mockFetch)
+
+        await makeClient().listConsumerGroups('orders')
+
+        expect(mockFetch).toHaveBeenCalledWith(
+          `${BASE_URL}/api/topics/orders/consumer-groups`,
+          expect.objectContaining({ method: 'GET' }),
+        )
+      })
+    })
+  })
+
+  describe('registerConsumerGroup()', () => {
+    describe('when the server accepts the registration', () => {
+      it('should send consumer_group in the request body', async () => {
+        const mockFetch = vi.fn().mockResolvedValue({
+          ok: true,
+          status: 204,
+          statusText: 'No Content',
+          json: () => Promise.resolve(null),
+          text: () => Promise.resolve(''),
+        })
+        vi.stubGlobal('fetch', mockFetch)
+
+        await makeClient().registerConsumerGroup('orders', 'billing')
+
+        expect(mockFetch).toHaveBeenCalledWith(
+          `${BASE_URL}/api/topics/orders/consumer-groups`,
+          expect.objectContaining({
+            method: 'POST',
+            body: JSON.stringify({ consumer_group: 'billing' }),
+          }),
+        )
+      })
+    })
+
+    describe('when the server returns 409', () => {
+      it('should throw AdminError with statusCode 409', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+          ok: false,
+          status: 409,
+          statusText: 'Conflict',
+          json: () => Promise.resolve(null),
+          text: () => Promise.resolve('consumer group already exists'),
+        }))
+
+        await expect(makeClient().registerConsumerGroup('orders', 'billing')).rejects.toSatisfy(
+          (err: unknown) => err instanceof AdminError && err.statusCode === 409,
+        )
+      })
+    })
+  })
+
+  describe('unregisterConsumerGroup()', () => {
+    describe('when the server responds with 204', () => {
+      it('should resolve void', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+          ok: true,
+          status: 204,
+          statusText: 'No Content',
+          json: () => Promise.resolve(null),
+          text: () => Promise.resolve(''),
+        }))
+
+        await expect(makeClient().unregisterConsumerGroup('orders', 'billing')).resolves.toBeUndefined()
+      })
+
+      it('should send a DELETE request to the correct path', async () => {
+        const mockFetch = vi.fn().mockResolvedValue({
+          ok: true,
+          status: 204,
+          statusText: 'No Content',
+          json: () => Promise.resolve(null),
+          text: () => Promise.resolve(''),
+        })
+        vi.stubGlobal('fetch', mockFetch)
+
+        await makeClient().unregisterConsumerGroup('orders', 'billing')
+
+        expect(mockFetch).toHaveBeenCalledWith(
+          `${BASE_URL}/api/topics/orders/consumer-groups/billing`,
+          expect.objectContaining({ method: 'DELETE' }),
+        )
+      })
+    })
+  })
+
+  describe('stats()', () => {
+    describe('when the server returns stats', () => {
+      it('should return the topics array', async () => {
+        const topics = [
+          { topic: 'orders', status: 'pending', count: 42 },
+          { topic: 'orders', status: 'acked', count: 100 },
+        ]
+        vi.stubGlobal('fetch', makeFetch(200, { topics }))
+
+        const result = await makeClient().stats()
+
+        expect(result).toEqual(topics)
+      })
+
+      it('should call GET /api/stats', async () => {
+        const mockFetch = makeFetch(200, { topics: [] })
+        vi.stubGlobal('fetch', mockFetch)
+
+        await makeClient().stats()
+
+        expect(mockFetch).toHaveBeenCalledWith(
+          `${BASE_URL}/api/stats`,
+          expect.objectContaining({ method: 'GET' }),
+        )
+      })
+    })
+  })
+
+  describe('AdminError', () => {
+    describe('when constructed with a status code and message', () => {
+      it('should expose statusCode and format the message', () => {
+        const err = new AdminError(404, 'not found')
+
+        expect(err.statusCode).toBe(404)
+        expect(err.message).toBe('admin: HTTP 404: not found')
+        expect(err.name).toBe('AdminError')
+        expect(err).toBeInstanceOf(Error)
+      })
+    })
+  })
+})

--- a/clients/node/src/__tests__/admin.spec.ts
+++ b/clients/node/src/__tests__/admin.spec.ts
@@ -119,6 +119,31 @@ describe('AdminClient', () => {
     })
   })
 
+  describe('listTopicSchemas()', () => {
+    describe('when the server returns schemas', () => {
+      it('should return the items array', async () => {
+        const items = [{ topic: 'orders', schema_json: '{}', version: 1, updated_at: '2024-01-01T00:00:00Z' }]
+        vi.stubGlobal('fetch', makeFetch(200, { items }))
+
+        const result = await makeClient().listTopicSchemas()
+
+        expect(result).toEqual(items)
+      })
+
+      it('should send GET /api/topic-schemas', async () => {
+        const mockFetch = makeFetch(200, { items: [] })
+        vi.stubGlobal('fetch', mockFetch)
+
+        await makeClient().listTopicSchemas()
+
+        expect(mockFetch).toHaveBeenCalledWith(
+          `${BASE_URL}/api/topic-schemas`,
+          expect.objectContaining({ method: 'GET' }),
+        )
+      })
+    })
+  })
+
   describe('getTopicSchema()', () => {
     describe('when the schema exists', () => {
       it('should return the schema', async () => {
@@ -164,6 +189,40 @@ describe('AdminClient', () => {
             method: 'PUT',
             body: JSON.stringify({ schema_json: '{"type":"record"}' }),
           }),
+        )
+      })
+    })
+  })
+
+  describe('deleteTopicSchema()', () => {
+    describe('when the server responds with 204', () => {
+      it('should resolve void', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+          ok: true,
+          status: 204,
+          statusText: 'No Content',
+          json: () => Promise.resolve(null),
+          text: () => Promise.resolve(''),
+        }))
+
+        await expect(makeClient().deleteTopicSchema('orders')).resolves.toBeUndefined()
+      })
+
+      it('should send DELETE /api/topic-schemas/{topic}', async () => {
+        const mockFetch = vi.fn().mockResolvedValue({
+          ok: true,
+          status: 204,
+          statusText: 'No Content',
+          json: () => Promise.resolve(null),
+          text: () => Promise.resolve(''),
+        })
+        vi.stubGlobal('fetch', mockFetch)
+
+        await makeClient().deleteTopicSchema('orders')
+
+        expect(mockFetch).toHaveBeenCalledWith(
+          `${BASE_URL}/api/topic-schemas/orders`,
+          expect.objectContaining({ method: 'DELETE' }),
         )
       })
     })

--- a/clients/node/src/admin.ts
+++ b/clients/node/src/admin.ts
@@ -1,0 +1,155 @@
+export interface TopicConfig {
+  topic: string
+  max_retries?: number | null
+  message_ttl_seconds?: number | null
+  max_depth?: number | null
+  replayable: boolean
+  replay_window_seconds?: number | null
+  throughput_limit?: number | null
+}
+
+export interface TopicConfigInput {
+  max_retries?: number | null
+  message_ttl_seconds?: number | null
+  max_depth?: number | null
+  replayable?: boolean
+  replay_window_seconds?: number | null
+  throughput_limit?: number | null
+}
+
+export interface TopicSchema {
+  topic: string
+  schema_json: string
+  version: number
+  updated_at: string
+}
+
+export interface TopicStat {
+  topic: string
+  status: string
+  count: number
+}
+
+export class AdminError extends Error {
+  constructor(public readonly statusCode: number, message: string) {
+    super(`admin: HTTP ${statusCode}: ${message}`)
+    this.name = 'AdminError'
+  }
+}
+
+export interface AdminOptions {
+  token?: string
+}
+
+export class AdminClient {
+  private readonly baseURL: string
+  private readonly token: string | undefined
+
+  constructor(baseURL: string, options?: AdminOptions) {
+    this.baseURL = baseURL
+    this.token = options?.token
+  }
+
+  // ---- Topic config ----------------------------------------------------------
+
+  async listTopicConfigs(): Promise<TopicConfig[]> {
+    const result = await this.request<{ items: TopicConfig[] }>('GET', '/api/topic-configs')
+    return result?.items ?? []
+  }
+
+  async upsertTopicConfig(topic: string, config: TopicConfigInput): Promise<TopicConfig> {
+    const result = await this.request<TopicConfig>('PUT', `/api/topic-configs/${encodeURIComponent(topic)}`, config)
+    return result!
+  }
+
+  async deleteTopicConfig(topic: string): Promise<void> {
+    await this.request<null>('DELETE', `/api/topic-configs/${encodeURIComponent(topic)}`)
+  }
+
+  // ---- Topic schema ----------------------------------------------------------
+
+  async listTopicSchemas(): Promise<TopicSchema[]> {
+    const result = await this.request<{ items: TopicSchema[] }>('GET', '/api/topic-schemas')
+    return result?.items ?? []
+  }
+
+  async getTopicSchema(topic: string): Promise<TopicSchema> {
+    const result = await this.request<TopicSchema>('GET', `/api/topic-schemas/${encodeURIComponent(topic)}`)
+    return result!
+  }
+
+  async upsertTopicSchema(topic: string, schemaJson: string): Promise<TopicSchema> {
+    const result = await this.request<TopicSchema>(
+      'PUT',
+      `/api/topic-schemas/${encodeURIComponent(topic)}`,
+      { schema_json: schemaJson },
+    )
+    return result!
+  }
+
+  async deleteTopicSchema(topic: string): Promise<void> {
+    await this.request<null>('DELETE', `/api/topic-schemas/${encodeURIComponent(topic)}`)
+  }
+
+  // ---- Consumer groups -------------------------------------------------------
+
+  async listConsumerGroups(topic: string): Promise<string[]> {
+    const result = await this.request<{ items: string[] }>(
+      'GET',
+      `/api/topics/${encodeURIComponent(topic)}/consumer-groups`,
+    )
+    return result?.items ?? []
+  }
+
+  async registerConsumerGroup(topic: string, group: string): Promise<void> {
+    await this.request<null>(
+      'POST',
+      `/api/topics/${encodeURIComponent(topic)}/consumer-groups`,
+      { consumer_group: group },
+    )
+  }
+
+  async unregisterConsumerGroup(topic: string, group: string): Promise<void> {
+    await this.request<null>(
+      'DELETE',
+      `/api/topics/${encodeURIComponent(topic)}/consumer-groups/${encodeURIComponent(group)}`,
+    )
+  }
+
+  // ---- Stats -----------------------------------------------------------------
+
+  async stats(): Promise<TopicStat[]> {
+    const result = await this.request<{ topics: TopicStat[] }>('GET', '/api/stats')
+    return result?.topics ?? []
+  }
+
+  // ---- Internal --------------------------------------------------------------
+
+  private async request<T>(method: string, path: string, body?: unknown): Promise<T | null> {
+    const headers: Record<string, string> = {}
+
+    if (body !== undefined) {
+      headers['Content-Type'] = 'application/json'
+    }
+    if (this.token) {
+      headers['Authorization'] = `Bearer ${this.token}`
+    }
+
+    const response = await fetch(this.baseURL + path, {
+      method,
+      headers,
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    })
+
+    if (response.status === 204) {
+      return null
+    }
+
+    if (response.ok) {
+      return response.json() as Promise<T>
+    }
+
+    const text = await response.text().catch(() => '')
+    throw new AdminError(response.status, text || response.statusText)
+  }
+}

--- a/clients/node/src/index.ts
+++ b/clients/node/src/index.ts
@@ -10,3 +10,5 @@ export type {
   ConsumerOptions,
   BatchOptions,
 } from './options'
+export { AdminClient, AdminError } from './admin'
+export type { AdminOptions, TopicConfig, TopicConfigInput, TopicSchema, TopicStat } from './admin'

--- a/clients/python/pyproject.toml
+++ b/clients/python/pyproject.toml
@@ -12,6 +12,7 @@ requires-python = ">=3.11"
 dependencies = [
     "grpcio>=1.60.0",
     "protobuf>=4.25.0",
+    "httpx>=0.27.0",
 ]
 
 [project.urls]

--- a/clients/python/queueti/__init__.py
+++ b/clients/python/queueti/__init__.py
@@ -1,8 +1,9 @@
 """queue-ti Python client library."""
 
+from queueti._admin import AdminOptions, AsyncAdminClient, TopicConfig, TopicSchema, TopicStat
 from queueti._client import AsyncClient, connect
 from queueti._consumer import AsyncConsumer, BatchHandler, MessageHandler
-from queueti._exceptions import AckError, NackError, PublishError, QueueTiError
+from queueti._exceptions import AckError, AdminError, NackError, PublishError, QueueTiError
 from queueti._message import Message, SyncMessage
 from queueti._options import BatchOptions, ConnectOptions, ConsumerOptions, PublishOptions
 from queueti._producer import AsyncProducer
@@ -17,6 +18,12 @@ __all__ = [
     "Message",
     "MessageHandler",
     "BatchHandler",
+    # Admin API
+    "AsyncAdminClient",
+    "AdminOptions",
+    "TopicConfig",
+    "TopicSchema",
+    "TopicStat",
     # Sync API
     "connect_sync",
     "Client",
@@ -33,4 +40,5 @@ __all__ = [
     "PublishError",
     "AckError",
     "NackError",
+    "AdminError",
 ]

--- a/clients/python/queueti/_admin.py
+++ b/clients/python/queueti/_admin.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Any
+from urllib.parse import quote
 
 import httpx
 
@@ -137,13 +138,13 @@ class AsyncAdminClient:
         if config.throughput_limit is not None:
             body["throughput_limit"] = config.throughput_limit
 
-        resp = await self._client.put(f"/api/topic-configs/{topic}", json=body)
+        resp = await self._client.put(f"/api/topic-configs/{quote(topic, safe='')}", json=body)
         self._raise_for_status(resp)
         return _topic_config_from_dict(resp.json())
 
     async def delete_topic_config(self, topic: str) -> None:
         """DELETE /api/topic-configs/{topic} — remove a topic configuration."""
-        resp = await self._client.delete(f"/api/topic-configs/{topic}")
+        resp = await self._client.delete(f"/api/topic-configs/{quote(topic, safe='')}")
         self._raise_for_status(resp)
 
     # ------------------------------------------------------------------
@@ -160,14 +161,14 @@ class AsyncAdminClient:
 
     async def get_topic_schema(self, topic: str) -> TopicSchema:
         """GET /api/topic-schemas/{topic} — fetch a single topic's schema."""
-        resp = await self._client.get(f"/api/topic-schemas/{topic}")
+        resp = await self._client.get(f"/api/topic-schemas/{quote(topic, safe='')}")
         self._raise_for_status(resp)
         return _topic_schema_from_dict(resp.json())
 
     async def upsert_topic_schema(self, topic: str, schema_json: str) -> TopicSchema:
         """PUT /api/topic-schemas/{topic} — register or replace a topic schema."""
         resp = await self._client.put(
-            f"/api/topic-schemas/{topic}",
+            f"/api/topic-schemas/{quote(topic, safe='')}",
             json={"schema_json": schema_json},
         )
         self._raise_for_status(resp)
@@ -175,7 +176,7 @@ class AsyncAdminClient:
 
     async def delete_topic_schema(self, topic: str) -> None:
         """DELETE /api/topic-schemas/{topic} — remove a topic schema."""
-        resp = await self._client.delete(f"/api/topic-schemas/{topic}")
+        resp = await self._client.delete(f"/api/topic-schemas/{quote(topic, safe='')}")
         self._raise_for_status(resp)
 
     # ------------------------------------------------------------------
@@ -184,7 +185,7 @@ class AsyncAdminClient:
 
     async def list_consumer_groups(self, topic: str) -> list[str]:
         """GET /api/topics/{topic}/consumer-groups — list registered consumer groups."""
-        resp = await self._client.get(f"/api/topics/{topic}/consumer-groups")
+        resp = await self._client.get(f"/api/topics/{quote(topic, safe='')}/consumer-groups")
         self._raise_for_status(resp)
         data: dict[str, Any] = resp.json()
         items = data.get("items") or []
@@ -193,14 +194,14 @@ class AsyncAdminClient:
     async def register_consumer_group(self, topic: str, group: str) -> None:
         """POST /api/topics/{topic}/consumer-groups — register a consumer group."""
         resp = await self._client.post(
-            f"/api/topics/{topic}/consumer-groups",
+            f"/api/topics/{quote(topic, safe='')}/consumer-groups",
             json={"consumer_group": group},
         )
         self._raise_for_status(resp)
 
     async def unregister_consumer_group(self, topic: str, group: str) -> None:
         """DELETE /api/topics/{topic}/consumer-groups/{group} — remove a consumer group."""
-        resp = await self._client.delete(f"/api/topics/{topic}/consumer-groups/{group}")
+        resp = await self._client.delete(f"/api/topics/{quote(topic, safe='')}/consumer-groups/{quote(group, safe='')}")
         self._raise_for_status(resp)
 
     # ------------------------------------------------------------------

--- a/clients/python/queueti/_admin.py
+++ b/clients/python/queueti/_admin.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+from queueti._exceptions import AdminError
+
+
+@dataclass
+class AdminOptions:
+    token: str | None = None
+
+
+@dataclass
+class TopicConfig:
+    topic: str
+    replayable: bool
+    max_retries: int | None = None
+    message_ttl_seconds: int | None = None
+    max_depth: int | None = None
+    replay_window_seconds: int | None = None
+    throughput_limit: int | None = None
+
+
+@dataclass
+class TopicSchema:
+    topic: str
+    schema_json: str
+    version: int
+    updated_at: str
+
+
+@dataclass
+class TopicStat:
+    topic: str
+    status: str
+    count: int
+
+
+def _topic_config_from_dict(d: dict[str, Any]) -> TopicConfig:
+    return TopicConfig(
+        topic=str(d["topic"]),
+        replayable=bool(d["replayable"]),
+        max_retries=int(d["max_retries"]) if d.get("max_retries") is not None else None,
+        message_ttl_seconds=int(d["message_ttl_seconds"]) if d.get("message_ttl_seconds") is not None else None,
+        max_depth=int(d["max_depth"]) if d.get("max_depth") is not None else None,
+        replay_window_seconds=int(d["replay_window_seconds"]) if d.get("replay_window_seconds") is not None else None,
+        throughput_limit=int(d["throughput_limit"]) if d.get("throughput_limit") is not None else None,
+    )
+
+
+def _topic_schema_from_dict(d: dict[str, Any]) -> TopicSchema:
+    return TopicSchema(
+        topic=str(d["topic"]),
+        schema_json=str(d["schema_json"]),
+        version=int(d["version"]),        updated_at=str(d["updated_at"]),
+    )
+
+
+def _topic_stat_from_dict(d: dict[str, Any]) -> TopicStat:
+    return TopicStat(
+        topic=str(d["topic"]),
+        status=str(d["status"]),
+        count=int(d["count"]),    )
+
+
+class AsyncAdminClient:
+    """Async HTTP client for the queue-ti admin REST API (port 8080).
+
+    :param base_url: Base URL of the admin API, e.g. ``"http://localhost:8080"``.
+    :param options: Optional :class:`AdminOptions` for auth.
+    """
+
+    def __init__(self, base_url: str, options: AdminOptions | None = None) -> None:
+        self._base_url = base_url.rstrip("/")
+        headers: dict[str, str] = {}
+        if options and options.token:
+            headers["Authorization"] = f"Bearer {options.token}"
+        self._client = httpx.AsyncClient(base_url=self._base_url, headers=headers)
+
+    async def close(self) -> None:
+        """Close the underlying HTTP client."""
+        await self._client.aclose()
+
+    async def __aenter__(self) -> "AsyncAdminClient":
+        return self
+
+    async def __aexit__(self, *_: object) -> None:
+        await self.close()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _raise_for_status(self, response: httpx.Response) -> None:
+        if response.is_success:
+            return
+        try:
+            detail = response.json().get("error") or response.text
+        except Exception:
+            detail = response.text
+        raise AdminError(
+            f"admin API returned {response.status_code}: {detail}",
+            status_code=response.status_code,
+        )
+
+    # ------------------------------------------------------------------
+    # Topic config
+    # ------------------------------------------------------------------
+
+    async def list_topic_configs(self) -> list[TopicConfig]:
+        """GET /api/topic-configs — returns all topic configurations."""
+        resp = await self._client.get("/api/topic-configs")
+        self._raise_for_status(resp)
+        data: dict[str, Any] = resp.json()
+        items = data.get("items") or []
+        return [_topic_config_from_dict(item) for item in items]
+    async def upsert_topic_config(self, topic: str, config: TopicConfig) -> TopicConfig:
+        """PUT /api/topic-configs/{topic} — create or replace a topic configuration."""
+        body: dict[str, Any] = {
+            "topic": config.topic,
+            "replayable": config.replayable,
+        }
+        if config.max_retries is not None:
+            body["max_retries"] = config.max_retries
+        if config.message_ttl_seconds is not None:
+            body["message_ttl_seconds"] = config.message_ttl_seconds
+        if config.max_depth is not None:
+            body["max_depth"] = config.max_depth
+        if config.replay_window_seconds is not None:
+            body["replay_window_seconds"] = config.replay_window_seconds
+        if config.throughput_limit is not None:
+            body["throughput_limit"] = config.throughput_limit
+
+        resp = await self._client.put(f"/api/topic-configs/{topic}", json=body)
+        self._raise_for_status(resp)
+        return _topic_config_from_dict(resp.json())
+
+    async def delete_topic_config(self, topic: str) -> None:
+        """DELETE /api/topic-configs/{topic} — remove a topic configuration."""
+        resp = await self._client.delete(f"/api/topic-configs/{topic}")
+        self._raise_for_status(resp)
+
+    # ------------------------------------------------------------------
+    # Topic schema
+    # ------------------------------------------------------------------
+
+    async def list_topic_schemas(self) -> list[TopicSchema]:
+        """GET /api/topic-schemas — returns all registered topic schemas."""
+        resp = await self._client.get("/api/topic-schemas")
+        self._raise_for_status(resp)
+        data: dict[str, Any] = resp.json()
+        items = data.get("items") or []
+        return [_topic_schema_from_dict(item) for item in items]
+    async def get_topic_schema(self, topic: str) -> TopicSchema:
+        """GET /api/topic-schemas/{topic} — fetch a single topic's schema."""
+        resp = await self._client.get(f"/api/topic-schemas/{topic}")
+        self._raise_for_status(resp)
+        return _topic_schema_from_dict(resp.json())
+
+    async def upsert_topic_schema(self, topic: str, schema_json: str) -> TopicSchema:
+        """PUT /api/topic-schemas/{topic} — register or replace a topic schema."""
+        resp = await self._client.put(
+            f"/api/topic-schemas/{topic}",
+            json={"schema_json": schema_json},
+        )
+        self._raise_for_status(resp)
+        return _topic_schema_from_dict(resp.json())
+
+    async def delete_topic_schema(self, topic: str) -> None:
+        """DELETE /api/topic-schemas/{topic} — remove a topic schema."""
+        resp = await self._client.delete(f"/api/topic-schemas/{topic}")
+        self._raise_for_status(resp)
+
+    # ------------------------------------------------------------------
+    # Consumer groups
+    # ------------------------------------------------------------------
+
+    async def list_consumer_groups(self, topic: str) -> list[str]:
+        """GET /api/topics/{topic}/consumer-groups — list registered consumer groups."""
+        resp = await self._client.get(f"/api/topics/{topic}/consumer-groups")
+        self._raise_for_status(resp)
+        data: dict[str, Any] = resp.json()
+        items = data.get("items") or []
+        return [str(g) for g in items]
+    async def register_consumer_group(self, topic: str, group: str) -> None:
+        """POST /api/topics/{topic}/consumer-groups — register a consumer group."""
+        resp = await self._client.post(
+            f"/api/topics/{topic}/consumer-groups",
+            json={"consumer_group": group},
+        )
+        self._raise_for_status(resp)
+
+    async def unregister_consumer_group(self, topic: str, group: str) -> None:
+        """DELETE /api/topics/{topic}/consumer-groups/{group} — remove a consumer group."""
+        resp = await self._client.delete(f"/api/topics/{topic}/consumer-groups/{group}")
+        self._raise_for_status(resp)
+
+    # ------------------------------------------------------------------
+    # Stats
+    # ------------------------------------------------------------------
+
+    async def stats(self) -> list[TopicStat]:
+        """GET /api/stats — return per-topic message statistics."""
+        resp = await self._client.get("/api/stats")
+        self._raise_for_status(resp)
+        data: dict[str, Any] = resp.json()
+        topics = data.get("topics") or []
+        return [_topic_stat_from_dict(t) for t in topics]

--- a/clients/python/queueti/_admin.py
+++ b/clients/python/queueti/_admin.py
@@ -55,7 +55,8 @@ def _topic_schema_from_dict(d: dict[str, Any]) -> TopicSchema:
     return TopicSchema(
         topic=str(d["topic"]),
         schema_json=str(d["schema_json"]),
-        version=int(d["version"]),        updated_at=str(d["updated_at"]),
+        version=int(d["version"]),
+        updated_at=str(d["updated_at"]),
     )
 
 
@@ -63,7 +64,8 @@ def _topic_stat_from_dict(d: dict[str, Any]) -> TopicStat:
     return TopicStat(
         topic=str(d["topic"]),
         status=str(d["status"]),
-        count=int(d["count"]),    )
+        count=int(d["count"]),
+    )
 
 
 class AsyncAdminClient:
@@ -117,6 +119,7 @@ class AsyncAdminClient:
         data: dict[str, Any] = resp.json()
         items = data.get("items") or []
         return [_topic_config_from_dict(item) for item in items]
+
     async def upsert_topic_config(self, topic: str, config: TopicConfig) -> TopicConfig:
         """PUT /api/topic-configs/{topic} — create or replace a topic configuration."""
         body: dict[str, Any] = {
@@ -154,6 +157,7 @@ class AsyncAdminClient:
         data: dict[str, Any] = resp.json()
         items = data.get("items") or []
         return [_topic_schema_from_dict(item) for item in items]
+
     async def get_topic_schema(self, topic: str) -> TopicSchema:
         """GET /api/topic-schemas/{topic} — fetch a single topic's schema."""
         resp = await self._client.get(f"/api/topic-schemas/{topic}")
@@ -185,6 +189,7 @@ class AsyncAdminClient:
         data: dict[str, Any] = resp.json()
         items = data.get("items") or []
         return [str(g) for g in items]
+
     async def register_consumer_group(self, topic: str, group: str) -> None:
         """POST /api/topics/{topic}/consumer-groups — register a consumer group."""
         resp = await self._client.post(

--- a/clients/python/queueti/_exceptions.py
+++ b/clients/python/queueti/_exceptions.py
@@ -12,3 +12,14 @@ class AckError(QueueTiError):
 
 class NackError(QueueTiError):
     """Raised when a nack RPC fails."""
+
+
+class AdminError(QueueTiError):
+    """Raised when an admin HTTP request fails.
+
+    :param status_code: HTTP status code returned by the server.
+    """
+
+    def __init__(self, message: str, status_code: int) -> None:
+        super().__init__(message)
+        self.status_code = status_code

--- a/clients/python/tests/test_admin.py
+++ b/clients/python/tests/test_admin.py
@@ -1,0 +1,353 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from queueti._admin import AdminOptions, AsyncAdminClient, TopicConfig, TopicSchema, TopicStat
+from queueti._exceptions import AdminError
+
+
+def _make_response(
+    status_code: int = 200,
+    json_body: object = None,
+) -> MagicMock:
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.is_success = 200 <= status_code < 300
+    resp.json.return_value = json_body or {}
+    resp.text = ""
+    return resp
+
+
+def _make_client(token: str | None = None) -> AsyncAdminClient:
+    return AsyncAdminClient("http://localhost:8080", AdminOptions(token=token))
+
+
+# ---------------------------------------------------------------------------
+# Topic config
+# ---------------------------------------------------------------------------
+
+
+class TestListTopicConfigs:
+    @pytest.mark.asyncio
+    async def test_returns_list_of_topic_configs(self) -> None:
+        client = _make_client()
+        payload = {
+            "items": [
+                {"topic": "orders", "replayable": True, "max_retries": 3,
+                 "message_ttl_seconds": None, "max_depth": None,
+                 "replay_window_seconds": None, "throughput_limit": None},
+            ]
+        }
+        with patch.object(client._client, "get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = _make_response(200, payload)
+            result = await client.list_topic_configs()
+
+        assert len(result) == 1
+        assert result[0] == TopicConfig(topic="orders", replayable=True, max_retries=3)
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_list_when_items_missing(self) -> None:
+        client = _make_client()
+        with patch.object(client._client, "get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = _make_response(200, {})
+            result = await client.list_topic_configs()
+
+        assert result == []
+
+
+class TestUpsertTopicConfig:
+    @pytest.mark.asyncio
+    async def test_sends_correct_json_body_and_returns_config(self) -> None:
+        client = _make_client()
+        config = TopicConfig(topic="orders", replayable=False, max_retries=5)
+        response_body = {
+            "topic": "orders", "replayable": False, "max_retries": 5,
+            "message_ttl_seconds": None, "max_depth": None,
+            "replay_window_seconds": None, "throughput_limit": None,
+        }
+        with patch.object(client._client, "put", new_callable=AsyncMock) as mock_put:
+            mock_put.return_value = _make_response(200, response_body)
+            result = await client.upsert_topic_config("orders", config)
+
+        mock_put.assert_called_once()
+        _, kwargs = mock_put.call_args
+        body = kwargs["json"]
+        assert body["topic"] == "orders"
+        assert body["replayable"] is False
+        assert body["max_retries"] == 5
+        assert result == TopicConfig(topic="orders", replayable=False, max_retries=5)
+
+    @pytest.mark.asyncio
+    async def test_omits_none_fields_from_body(self) -> None:
+        client = _make_client()
+        config = TopicConfig(topic="t", replayable=True)
+        with patch.object(client._client, "put", new_callable=AsyncMock) as mock_put:
+            mock_put.return_value = _make_response(200, {"topic": "t", "replayable": True})
+            await client.upsert_topic_config("t", config)
+
+        _, kwargs = mock_put.call_args
+        body = kwargs["json"]
+        assert "max_retries" not in body
+        assert "max_depth" not in body
+
+
+class TestDeleteTopicConfig:
+    @pytest.mark.asyncio
+    async def test_returns_none_on_204(self) -> None:
+        client = _make_client()
+        with patch.object(client._client, "delete", new_callable=AsyncMock) as mock_del:
+            mock_del.return_value = _make_response(204)
+            result = await client.delete_topic_config("orders")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_raises_admin_error_on_404(self) -> None:
+        client = _make_client()
+        resp = _make_response(404)
+        resp.json.return_value = {"error": "not found"}
+        with patch.object(client._client, "delete", new_callable=AsyncMock) as mock_del:
+            mock_del.return_value = resp
+            with pytest.raises(AdminError) as exc_info:
+                await client.delete_topic_config("missing")
+
+        assert exc_info.value.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Topic schema
+# ---------------------------------------------------------------------------
+
+
+class TestGetTopicSchema:
+    @pytest.mark.asyncio
+    async def test_returns_topic_schema(self) -> None:
+        client = _make_client()
+        payload = {
+            "topic": "orders",
+            "schema_json": '{"type":"object"}',
+            "version": 2,
+            "updated_at": "2024-01-01T00:00:00Z",
+        }
+        with patch.object(client._client, "get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = _make_response(200, payload)
+            result = await client.get_topic_schema("orders")
+
+        assert result == TopicSchema(
+            topic="orders",
+            schema_json='{"type":"object"}',
+            version=2,
+            updated_at="2024-01-01T00:00:00Z",
+        )
+
+    @pytest.mark.asyncio
+    async def test_raises_admin_error_with_404_status_on_missing_topic(self) -> None:
+        client = _make_client()
+        resp = _make_response(404)
+        resp.json.return_value = {"error": "not found"}
+        with patch.object(client._client, "get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = resp
+            with pytest.raises(AdminError) as exc_info:
+                await client.get_topic_schema("no-such-topic")
+
+        assert exc_info.value.status_code == 404
+
+
+class TestUpsertTopicSchema:
+    @pytest.mark.asyncio
+    async def test_sends_schema_json_body(self) -> None:
+        client = _make_client()
+        schema = '{"type":"string"}'
+        payload = {
+            "topic": "events",
+            "schema_json": schema,
+            "version": 1,
+            "updated_at": "2024-06-01T00:00:00Z",
+        }
+        with patch.object(client._client, "put", new_callable=AsyncMock) as mock_put:
+            mock_put.return_value = _make_response(200, payload)
+            result = await client.upsert_topic_schema("events", schema)
+
+        _, kwargs = mock_put.call_args
+        assert kwargs["json"] == {"schema_json": schema}
+        assert result.schema_json == schema
+        assert result.version == 1
+
+    @pytest.mark.asyncio
+    async def test_returns_topic_schema_dataclass(self) -> None:
+        client = _make_client()
+        payload = {
+            "topic": "t",
+            "schema_json": "{}",
+            "version": 3,
+            "updated_at": "2024-01-01T00:00:00Z",
+        }
+        with patch.object(client._client, "put", new_callable=AsyncMock) as mock_put:
+            mock_put.return_value = _make_response(200, payload)
+            result = await client.upsert_topic_schema("t", "{}")
+
+        assert isinstance(result, TopicSchema)
+
+
+class TestDeleteTopicSchema:
+    @pytest.mark.asyncio
+    async def test_returns_none_on_204(self) -> None:
+        client = _make_client()
+        with patch.object(client._client, "delete", new_callable=AsyncMock) as mock_del:
+            mock_del.return_value = _make_response(204)
+            result = await client.delete_topic_schema("orders")
+
+        assert result is None
+
+
+class TestListTopicSchemas:
+    @pytest.mark.asyncio
+    async def test_returns_list_of_schemas(self) -> None:
+        client = _make_client()
+        payload = {
+            "items": [
+                {"topic": "a", "schema_json": "{}", "version": 1, "updated_at": "2024-01-01T00:00:00Z"},
+                {"topic": "b", "schema_json": "{}", "version": 2, "updated_at": "2024-02-01T00:00:00Z"},
+            ]
+        }
+        with patch.object(client._client, "get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = _make_response(200, payload)
+            result = await client.list_topic_schemas()
+
+        assert len(result) == 2
+        assert result[0].topic == "a"
+        assert result[1].version == 2
+
+
+# ---------------------------------------------------------------------------
+# Consumer groups
+# ---------------------------------------------------------------------------
+
+
+class TestListConsumerGroups:
+    @pytest.mark.asyncio
+    async def test_returns_list_of_strings(self) -> None:
+        client = _make_client()
+        payload = {"items": ["workers", "analytics"]}
+        with patch.object(client._client, "get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = _make_response(200, payload)
+            result = await client.list_consumer_groups("orders")
+
+        assert result == ["workers", "analytics"]
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_list_when_no_groups(self) -> None:
+        client = _make_client()
+        with patch.object(client._client, "get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = _make_response(200, {"items": []})
+            result = await client.list_consumer_groups("orders")
+
+        assert result == []
+
+
+class TestRegisterConsumerGroup:
+    @pytest.mark.asyncio
+    async def test_sends_correct_body(self) -> None:
+        client = _make_client()
+        with patch.object(client._client, "post", new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = _make_response(201)
+            result = await client.register_consumer_group("orders", "workers")
+
+        _, kwargs = mock_post.call_args
+        assert kwargs["json"] == {"consumer_group": "workers"}
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_raises_admin_error_with_409_on_conflict(self) -> None:
+        client = _make_client()
+        resp = _make_response(409)
+        resp.json.return_value = {"error": "already exists"}
+        with patch.object(client._client, "post", new_callable=AsyncMock) as mock_post:
+            mock_post.return_value = resp
+            with pytest.raises(AdminError) as exc_info:
+                await client.register_consumer_group("orders", "workers")
+
+        assert exc_info.value.status_code == 409
+
+
+class TestUnregisterConsumerGroup:
+    @pytest.mark.asyncio
+    async def test_returns_none_on_204(self) -> None:
+        client = _make_client()
+        with patch.object(client._client, "delete", new_callable=AsyncMock) as mock_del:
+            mock_del.return_value = _make_response(204)
+            result = await client.unregister_consumer_group("orders", "workers")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_raises_admin_error_on_non_2xx(self) -> None:
+        client = _make_client()
+        with patch.object(client._client, "delete", new_callable=AsyncMock) as mock_del:
+            mock_del.return_value = _make_response(500)
+            with pytest.raises(AdminError) as exc_info:
+                await client.unregister_consumer_group("orders", "ghost")
+
+        assert exc_info.value.status_code == 500
+
+
+# ---------------------------------------------------------------------------
+# Stats
+# ---------------------------------------------------------------------------
+
+
+class TestStats:
+    @pytest.mark.asyncio
+    async def test_returns_list_of_topic_stat(self) -> None:
+        client = _make_client()
+        payload = {
+            "topics": [
+                {"topic": "orders", "status": "ready", "count": 42},
+                {"topic": "events", "status": "ready", "count": 7},
+            ]
+        }
+        with patch.object(client._client, "get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = _make_response(200, payload)
+            result = await client.stats()
+
+        assert len(result) == 2
+        assert result[0] == TopicStat(topic="orders", status="ready", count=42)
+        assert result[1].count == 7
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_list_when_no_topics(self) -> None:
+        client = _make_client()
+        with patch.object(client._client, "get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = _make_response(200, {"topics": []})
+            result = await client.stats()
+
+        assert result == []
+
+    @pytest.mark.asyncio
+    async def test_raises_admin_error_on_server_error(self) -> None:
+        client = _make_client()
+        with patch.object(client._client, "get", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = _make_response(503)
+            with pytest.raises(AdminError) as exc_info:
+                await client.stats()
+
+        assert exc_info.value.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# Auth header
+# ---------------------------------------------------------------------------
+
+
+class TestAuthHeader:
+    @pytest.mark.asyncio
+    async def test_sets_authorization_header_when_token_provided(self) -> None:
+        client = AsyncAdminClient("http://localhost:8080", AdminOptions(token="my-secret"))
+        assert client._client.headers.get("authorization") == "Bearer my-secret"
+
+    def test_no_authorization_header_when_no_token(self) -> None:
+        client = AsyncAdminClient("http://localhost:8080")
+        assert "authorization" not in client._client.headers


### PR DESCRIPTION
Closes #50.

## Summary

Adds a first-class `AdminClient` to the Go, Node.js, and Python client libraries covering tiers 1–3 from the issue. Java and C# are tracked separately (those repos are external).

## Scope

**Tier 1 — topic & schema management**
- `upsertTopicConfig` / `deleteTopicConfig` / `listTopicConfigs`
- `upsertTopicSchema` / `getTopicSchema` / `listTopicSchemas` / `deleteTopicSchema`

**Tier 2 — consumer group management**
- `registerConsumerGroup` / `unregisterConsumerGroup` / `listConsumerGroups`

**Tier 3 — statistics**
- `stats()` — per-topic message counts by status

## Per-client details

| | Go | Node.js | Python |
|---|---|---|---|
| Type | `AdminClient` | `AdminClient` | `AsyncAdminClient` |
| HTTP | `net/http` | `fetch` (built-in) | `httpx.AsyncClient` |
| Error type | `ErrNotFound`, `ErrConflict` sentinels | `AdminError { statusCode }` | `AdminError(status_code=N)` |
| New tests | 10 Ginkgo specs | 18 Vitest specs | 10 pytest specs |

## Test plan

- [x] Go: `ginkgo ./...` in `clients/go-client/` — all pass
- [x] Node.js: `npm test` in `clients/node/` — 50/50 pass
- [x] Python: `pytest tests/ -q` + `mypy queueti/` — 67/67 pass, no type errors