### PR TITLE
feat: order pipeline sample apps for Go, Node.js, and Python

### DIFF
--- a/clients/go-client/examples/order-pipeline/.gitignore
+++ b/clients/go-client/examples/order-pipeline/.gitignore
@@ -1,0 +1,1 @@
+order-pipeline

--- a/clients/go-client/examples/order-pipeline/README.md
+++ b/clients/go-client/examples/order-pipeline/README.md
@@ -1,0 +1,35 @@
+# Order Pipeline — Go
+
+Demonstrates the full producer → consumer → ack lifecycle using the queue-ti Go client.
+
+## What it does
+
+1. Registers the `fulfillment` consumer group via the admin REST API
+2. Publishes 5 orders to the `orders` topic (one is a poison pill)
+3. Consumes the topic with 3 concurrent handlers — valid orders are acked, the poison pill is nacked
+4. Drains the `orders.dlq` topic so dead-lettered messages are visible
+
+## Prerequisites
+
+- Go 1.21+
+- queue-ti running locally: `docker-compose up` from the repo root
+
+## Run
+
+```bash
+go run .
+```
+
+Press **Ctrl-C** to stop the consumer.
+
+## Configuration
+
+Edit the constants at the top of `main.go` to point at a different server:
+
+| Constant | Default | Description |
+|----------|---------|-------------|
+| `grpcAddr` | `localhost:50051` | gRPC server address |
+| `adminAddr` | `http://localhost:8080` | HTTP admin API base URL |
+| `topic` | `orders` | Topic to publish/consume |
+| `dlqTopic` | `orders.dlq` | Dead-letter queue topic |
+| `consumerGroup` | `fulfillment` | Consumer group name |

--- a/clients/go-client/examples/order-pipeline/main.go
+++ b/clients/go-client/examples/order-pipeline/main.go
@@ -56,9 +56,12 @@ func main() {
 // registerConsumerGroup calls the admin REST API to ensure the consumer group exists.
 func registerConsumerGroup(ctx context.Context) error {
 	body := fmt.Sprintf(`{"consumer_group":%q}`, consumerGroup)
-	req, _ := http.NewRequestWithContext(ctx, http.MethodPost,
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
 		fmt.Sprintf("%s/api/topics/%s/consumer-groups", adminAddr, topic),
 		strings.NewReader(body))
+	if err != nil {
+		return err
+	}
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := http.DefaultClient.Do(req)

--- a/clients/go-client/examples/order-pipeline/main.go
+++ b/clients/go-client/examples/order-pipeline/main.go
@@ -1,0 +1,150 @@
+// Order pipeline — demonstrates the full producer → consumer → ack lifecycle
+// against a local queue-ti instance.
+//
+// Run: go run . (requires docker-compose up)
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	queueti "github.com/Joessst-Dev/queue-ti/clients/go-client"
+)
+
+const (
+	grpcAddr      = "localhost:50051"
+	adminAddr     = "http://localhost:8080"
+	topic         = "orders"
+	dlqTopic      = "orders.dlq"
+	consumerGroup = "fulfillment"
+)
+
+type order struct {
+	ID     string `json:"id"`
+	Item   string `json:"item"`
+	Amount int    `json:"amount"`
+	Poison bool   `json:"poison,omitempty"` // triggers a nack to simulate failure
+}
+
+func main() {
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	client, err := queueti.Dial(grpcAddr, queueti.WithInsecure())
+	if err != nil {
+		log.Fatalf("dial: %v", err)
+	}
+	defer client.Close()
+
+	if err := registerConsumerGroup(ctx); err != nil {
+		log.Fatalf("register consumer group: %v", err)
+	}
+
+	go produce(ctx, client)
+	go drainDLQ(ctx, client)
+	consume(ctx, client)
+}
+
+// registerConsumerGroup calls the admin REST API to ensure the consumer group exists.
+func registerConsumerGroup(ctx context.Context) error {
+	body := fmt.Sprintf(`{"consumer_group":%q}`, consumerGroup)
+	req, _ := http.NewRequestWithContext(ctx, http.MethodPost,
+		fmt.Sprintf("%s/api/topics/%s/consumer-groups", adminAddr, topic),
+		strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusConflict {
+		return fmt.Errorf("unexpected status %d", resp.StatusCode)
+	}
+	log.Printf("consumer group %q ready", consumerGroup)
+	return nil
+}
+
+// produce publishes five orders — the third is a poison pill that will be nacked.
+func produce(ctx context.Context, client *queueti.Client) {
+	producer := client.NewProducer()
+	orders := []order{
+		{ID: "ord-1", Item: "Widget A", Amount: 2},
+		{ID: "ord-2", Item: "Gadget B", Amount: 1},
+		{ID: "ord-3", Item: "poison", Amount: 0, Poison: true},
+		{ID: "ord-4", Item: "Widget C", Amount: 5},
+		{ID: "ord-5", Item: "Gadget D", Amount: 3},
+	}
+
+	for _, o := range orders {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(500 * time.Millisecond):
+		}
+
+		payload, _ := json.Marshal(o)
+		opts := []queueti.PublishOption{
+			queueti.WithMetadata(map[string]string{"source": "order-pipeline"}),
+			queueti.WithKey(o.ID),
+		}
+		id, err := producer.Publish(ctx, topic, payload, opts...)
+		if err != nil {
+			log.Printf("publish %s: %v", o.ID, err)
+			continue
+		}
+		log.Printf("published %s → message %s", o.ID, id)
+	}
+}
+
+// consume streams from the orders topic; poisons are nacked and eventually land in the DLQ.
+func consume(ctx context.Context, client *queueti.Client) {
+	consumer := client.NewConsumer(topic,
+		queueti.WithConsumerGroup(consumerGroup),
+		queueti.WithConcurrency(3),
+	)
+	log.Printf("consuming from %q (group %q) — Ctrl-C to stop", topic, consumerGroup)
+
+	if err := consumer.Consume(ctx, handleOrder); err != nil {
+		log.Printf("consumer stopped: %v", err)
+	}
+}
+
+func handleOrder(ctx context.Context, msg *queueti.Message) error {
+	var o order
+	if err := json.Unmarshal(msg.Payload, &o); err != nil {
+		return fmt.Errorf("invalid payload: %w", err)
+	}
+
+	if o.Poison {
+		log.Printf("nack %s: poison pill detected (retry %d)", msg.ID, msg.RetryCount)
+		return fmt.Errorf("poison pill")
+	}
+
+	log.Printf("ack %s: processed order %s — %d×%s", msg.ID, o.ID, o.Amount, o.Item)
+	return nil
+}
+
+// drainDLQ polls the DLQ and logs dead-lettered messages.
+func drainDLQ(ctx context.Context, client *queueti.Client) {
+	consumer := client.NewConsumer(dlqTopic, queueti.WithConsumerGroup(consumerGroup))
+	log.Printf("draining DLQ %q", dlqTopic)
+
+	_ = consumer.ConsumeBatch(ctx, dlqTopic, 10, func(ctx context.Context, msgs []*queueti.Message) error {
+		for _, msg := range msgs {
+			log.Printf("[DLQ] %s retry=%d payload=%s", msg.ID, msg.RetryCount, msg.Payload)
+			if err := msg.Ack(ctx); err != nil {
+				log.Printf("[DLQ] ack failed: %v", err)
+			}
+		}
+		return nil
+	})
+}

--- a/clients/node/examples/order-pipeline/README.md
+++ b/clients/node/examples/order-pipeline/README.md
@@ -1,0 +1,39 @@
+# Order Pipeline — Node.js
+
+Demonstrates the full producer → consumer → ack lifecycle using the queue-ti Node.js client.
+
+## What it does
+
+1. Registers the `fulfillment` consumer group via the admin REST API
+2. Publishes 5 orders to the `orders` topic (one is a poison pill)
+3. Consumes the topic with 3 concurrent handlers — valid orders are acked, the poison pill is nacked
+4. Drains the `orders.dlq` topic so dead-lettered messages are visible
+
+## Prerequisites
+
+- Node.js 18+
+- `ts-node` available (`npm install -g ts-node` or `npx ts-node`)
+- queue-ti running locally: `docker-compose up` from the repo root
+
+## Run
+
+From the `clients/node/` directory:
+
+```bash
+npm install
+npx ts-node --esm examples/order-pipeline/index.ts
+```
+
+Press **Ctrl-C** to stop the consumer.
+
+## Configuration
+
+Edit the constants at the top of `index.ts`:
+
+| Constant | Default | Description |
+|----------|---------|-------------|
+| `GRPC_ADDR` | `localhost:50051` | gRPC server address |
+| `ADMIN_URL` | `http://localhost:8080` | HTTP admin API base URL |
+| `TOPIC` | `orders` | Topic to publish/consume |
+| `DLQ_TOPIC` | `orders.dlq` | Dead-letter queue topic |
+| `CONSUMER_GROUP` | `fulfillment` | Consumer group name |

--- a/clients/node/examples/order-pipeline/index.ts
+++ b/clients/node/examples/order-pipeline/index.ts
@@ -1,0 +1,135 @@
+/**
+ * Order pipeline — demonstrates the full producer → consumer → ack lifecycle
+ * against a local queue-ti instance.
+ *
+ * Run: npx ts-node index.ts (requires docker-compose up)
+ */
+
+import { connect, AdminClient } from '../../src'
+import type { Message } from '../../src/message'
+import type { BatchHandler, MessageHandler } from '../../src/consumer'
+
+const GRPC_ADDR = 'localhost:50051'
+const ADMIN_URL = 'http://localhost:8080'
+const TOPIC = 'orders'
+const DLQ_TOPIC = 'orders.dlq'
+const CONSUMER_GROUP = 'fulfillment'
+
+interface Order {
+  id: string
+  item: string
+  amount: number
+  poison?: boolean
+}
+
+const orders: Order[] = [
+  { id: 'ord-1', item: 'Widget A', amount: 2 },
+  { id: 'ord-2', item: 'Gadget B', amount: 1 },
+  { id: 'ord-3', item: 'poison', amount: 0, poison: true },
+  { id: 'ord-4', item: 'Widget C', amount: 5 },
+  { id: 'ord-5', item: 'Gadget D', amount: 3 },
+]
+
+async function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function registerConsumerGroup(): Promise<void> {
+  const admin = new AdminClient(ADMIN_URL)
+  try {
+    await admin.registerConsumerGroup(TOPIC, CONSUMER_GROUP)
+    console.log(`consumer group "${CONSUMER_GROUP}" registered`)
+  } catch (err: unknown) {
+    // 409 Conflict means the group already exists — that's fine
+    if (err instanceof Error && err.message.includes('409')) {
+      console.log(`consumer group "${CONSUMER_GROUP}" already exists`)
+    } else {
+      throw err
+    }
+  }
+}
+
+async function produce(controller: AbortController): Promise<void> {
+  const client = await connect(GRPC_ADDR, { insecure: true })
+  const producer = client.producer()
+
+  for (const order of orders) {
+    if (controller.signal.aborted) break
+    await sleep(500)
+    const payload = Buffer.from(JSON.stringify(order))
+    const id = await producer.publish(TOPIC, payload, {
+      metadata: { source: 'order-pipeline' },
+      key: order.id,
+    })
+    console.log(`published ${order.id} → message ${id}`)
+  }
+
+  client.close()
+}
+
+async function consume(controller: AbortController): Promise<void> {
+  const client = await connect(GRPC_ADDR, { insecure: true })
+  const consumer = client.consumer(TOPIC, {
+    consumerGroup: CONSUMER_GROUP,
+    concurrency: 3,
+    signal: controller.signal,
+  })
+
+  console.log(`consuming from "${TOPIC}" (group "${CONSUMER_GROUP}") — Ctrl-C to stop`)
+
+  const handler: MessageHandler = async (msg: Message) => {
+    const order: Order = JSON.parse(msg.payload.toString())
+
+    if (order.poison) {
+      console.log(`nack ${msg.id}: poison pill detected (retry ${msg.retryCount})`)
+      await msg.nack('poison pill')
+      return
+    }
+
+    console.log(`ack ${msg.id}: processed order ${order.id} — ${order.amount}×${order.item}`)
+    await msg.ack()
+  }
+
+  await consumer.consume(handler)
+  client.close()
+}
+
+async function drainDLQ(controller: AbortController): Promise<void> {
+  const client = await connect(GRPC_ADDR, { insecure: true })
+  const consumer = client.consumer(DLQ_TOPIC, { consumerGroup: CONSUMER_GROUP })
+
+  console.log(`draining DLQ "${DLQ_TOPIC}"`)
+
+  await consumer.consumeBatch(
+    { batchSize: 10, consumerGroup: CONSUMER_GROUP },
+    async (messages: Message[]) => {
+      for (const msg of messages) {
+        console.log(`[DLQ] ${msg.id} retry=${msg.retryCount} payload=${msg.payload.toString()}`)
+        await msg.ack()
+      }
+    },
+  )
+
+  client.close()
+}
+
+async function main(): Promise<void> {
+  const controller = new AbortController()
+
+  process.on('SIGINT', () => {
+    console.log('\nshutting down…')
+    controller.abort()
+  })
+  process.on('SIGTERM', () => controller.abort())
+
+  await registerConsumerGroup()
+
+  void produce(controller)
+  void drainDLQ(controller)
+  await consume(controller)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})

--- a/clients/node/examples/order-pipeline/index.ts
+++ b/clients/node/examples/order-pipeline/index.ts
@@ -7,7 +7,7 @@
 
 import { connect, AdminClient } from '../../src'
 import type { Message } from '../../src/message'
-import type { BatchHandler, MessageHandler } from '../../src/consumer'
+import type { MessageHandler } from '../../src/consumer'
 
 const GRPC_ADDR = 'localhost:50051'
 const ADMIN_URL = 'http://localhost:8080'

--- a/clients/python/examples/order_pipeline/README.md
+++ b/clients/python/examples/order_pipeline/README.md
@@ -1,0 +1,50 @@
+# Order Pipeline — Python
+
+Demonstrates the full producer → consumer → ack lifecycle using the queue-ti Python client.
+
+## What it does
+
+1. Registers the `fulfillment` consumer group via the admin REST API
+2. Publishes 5 orders to the `orders` topic (one is a poison pill)
+3. Consumes the topic with 3 concurrent handlers — valid orders are acked, the poison pill is nacked
+4. Drains the `orders.dlq` topic so dead-lettered messages are visible
+
+## Prerequisites
+
+- Python 3.11+
+- queue-ti running locally: `docker-compose up` from the repo root
+
+## Install dependencies
+
+From the `clients/python/` directory:
+
+```bash
+pip install -e ".[dev]"
+```
+
+Or with the project's virtual environment:
+
+```bash
+python -m venv .venv && source .venv/bin/activate
+pip install -e ".[dev]"
+```
+
+## Run
+
+```bash
+python examples/order_pipeline/main.py
+```
+
+Press **Ctrl-C** to stop the consumer.
+
+## Configuration
+
+Edit the constants at the top of `main.py`:
+
+| Constant | Default | Description |
+|----------|---------|-------------|
+| `GRPC_ADDR` | `localhost:50051` | gRPC server address |
+| `ADMIN_URL` | `http://localhost:8080` | HTTP admin API base URL |
+| `TOPIC` | `orders` | Topic to publish/consume |
+| `DLQ_TOPIC` | `orders.dlq` | Dead-letter queue topic |
+| `CONSUMER_GROUP` | `fulfillment` | Consumer group name |

--- a/clients/python/examples/order_pipeline/main.py
+++ b/clients/python/examples/order_pipeline/main.py
@@ -13,8 +13,6 @@ import json
 import logging
 import signal
 
-import httpx
-
 from queueti import (
     AsyncAdminClient,
     AdminError,

--- a/clients/python/examples/order_pipeline/main.py
+++ b/clients/python/examples/order_pipeline/main.py
@@ -1,0 +1,155 @@
+"""
+Order pipeline — demonstrates the full producer → consumer → ack lifecycle
+against a local queue-ti instance.
+
+Run: python main.py  (requires docker-compose up)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import json
+import logging
+import signal
+import sys
+
+import httpx
+
+from queueti import (
+    AsyncAdminClient,
+    AdminError,
+    BatchOptions,
+    ConnectOptions,
+    ConsumerOptions,
+    Message,
+    PublishOptions,
+    connect,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(message)s")
+log = logging.getLogger(__name__)
+
+GRPC_ADDR = "localhost:50051"
+ADMIN_URL = "http://localhost:8080"
+TOPIC = "orders"
+DLQ_TOPIC = "orders.dlq"
+CONSUMER_GROUP = "fulfillment"
+
+
+@dataclasses.dataclass
+class Order:
+    id: str
+    item: str
+    amount: int
+    poison: bool = False
+
+
+ORDERS = [
+    Order("ord-1", "Widget A", 2),
+    Order("ord-2", "Gadget B", 1),
+    Order("ord-3", "poison", 0, poison=True),
+    Order("ord-4", "Widget C", 5),
+    Order("ord-5", "Gadget D", 3),
+]
+
+
+async def register_consumer_group() -> None:
+    async with AsyncAdminClient(ADMIN_URL) as admin:
+        try:
+            await admin.register_consumer_group(TOPIC, CONSUMER_GROUP)
+            log.info("consumer group %r registered", CONSUMER_GROUP)
+        except AdminError as exc:
+            if exc.status_code == 409:
+                log.info("consumer group %r already exists", CONSUMER_GROUP)
+            else:
+                raise
+
+
+async def produce(stop: asyncio.Event) -> None:
+    client = await connect(GRPC_ADDR, ConnectOptions(insecure=True))
+    producer = client.producer()
+
+    for order in ORDERS:
+        if stop.is_set():
+            break
+        await asyncio.sleep(0.5)
+        payload = json.dumps(dataclasses.asdict(order)).encode()
+        msg_id = await producer.publish(
+            TOPIC,
+            payload,
+            PublishOptions(metadata={"source": "order-pipeline"}),
+        )
+        log.info("published %s → message %s", order.id, msg_id)
+
+    await client.close()
+
+
+async def consume(stop: asyncio.Event) -> None:
+    client = await connect(GRPC_ADDR, ConnectOptions(insecure=True))
+    consumer = client.consumer(
+        TOPIC,
+        ConsumerOptions(consumer_group=CONSUMER_GROUP, concurrency=3),
+    )
+    log.info("consuming from %r (group %r) — Ctrl-C to stop", TOPIC, CONSUMER_GROUP)
+
+    async def handler(msg: Message) -> None:
+        order = Order(**json.loads(msg.payload))
+
+        if order.poison:
+            log.info("nack %s: poison pill detected (retry %d)", msg.id, msg.retry_count)
+            await msg.nack("poison pill")
+            return
+
+        log.info("ack %s: processed order %s — %d×%s", msg.id, order.id, order.amount, order.item)
+        await msg.ack()
+
+    consume_task = asyncio.create_task(consumer.consume(handler))
+    await stop.wait()
+    consume_task.cancel()
+    try:
+        await consume_task
+    except asyncio.CancelledError:
+        pass
+
+    await client.close()
+
+
+async def drain_dlq() -> None:
+    client = await connect(GRPC_ADDR, ConnectOptions(insecure=True))
+    consumer = client.consumer(
+        DLQ_TOPIC,
+        ConsumerOptions(consumer_group=CONSUMER_GROUP),
+    )
+    log.info("draining DLQ %r", DLQ_TOPIC)
+
+    async def dlq_handler(messages: list[Message]) -> None:
+        for msg in messages:
+            log.info("[DLQ] %s retry=%d payload=%s", msg.id, msg.retry_count, msg.payload)
+            await msg.ack()
+
+    await consumer.consume_batch(BatchOptions(batch_size=10, consumer_group=CONSUMER_GROUP), dlq_handler)
+    await client.close()
+
+
+async def main() -> None:
+    stop = asyncio.Event()
+
+    def _shutdown() -> None:
+        log.info("shutting down…")
+        stop.set()
+
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        loop.add_signal_handler(sig, _shutdown)
+
+    await register_consumer_group()
+
+    async with asyncio.TaskGroup() as tg:
+        tg.create_task(produce(stop))
+        tg.create_task(drain_dlq())
+        tg.create_task(consume(stop))
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/clients/python/examples/order_pipeline/main.py
+++ b/clients/python/examples/order_pipeline/main.py
@@ -12,7 +12,6 @@ import dataclasses
 import json
 import logging
 import signal
-import sys
 
 import httpx
 

--- a/docs/clients/go.md
+++ b/docs/clients/go.md
@@ -308,6 +308,25 @@ The `AdminClient` covers:
 
 For complete examples and method signatures, see [clients/go-client/admin.go](https://github.com/Joessst-Dev/queue-ti/tree/main/clients/go-client/admin.go).
 
+## Sample Applications
+
+### Order Pipeline
+
+A self-contained end-to-end example demonstrating the full producer → consumer → ack lifecycle:
+
+- Client creation and consumer group registration via the admin REST API
+- Publishing messages with metadata and a deduplication key
+- Streaming consumption with `concurrency=3`, ack on success, nack on failure (poison pill)
+- DLQ drain — batch-polls `orders.dlq` and acks dead-lettered messages
+- Graceful shutdown on SIGINT/SIGTERM via `signal.NotifyContext`
+
+**Location**: [`clients/go-client/examples/order-pipeline/`](https://github.com/Joessst-Dev/queue-ti/tree/main/clients/go-client/examples/order-pipeline)
+
+```bash
+# Requires: docker-compose up (from repo root)
+go run .
+```
+
 ## Full Client Documentation
 
 For complete API reference and examples, see [clients/go-client/README.md](https://github.com/Joessst-Dev/queue-ti/tree/main/clients/go-client).

--- a/docs/clients/nodejs.md
+++ b/docs/clients/nodejs.md
@@ -301,6 +301,26 @@ The `AdminClient` covers:
 
 For complete examples and method signatures, see [clients/node/src/admin.ts](https://github.com/Joessst-Dev/queue-ti/tree/main/clients/node/src/admin.ts).
 
+## Sample Applications
+
+### Order Pipeline
+
+A self-contained end-to-end example demonstrating the full producer → consumer → ack lifecycle:
+
+- Client creation and consumer group registration via the admin REST API
+- Publishing messages with metadata and a deduplication key
+- Streaming consumption with `concurrency: 3`, ack on success, nack on failure (poison pill)
+- DLQ drain — batch-polls `orders.dlq` and acks dead-lettered messages
+- Graceful shutdown on SIGINT/SIGTERM via `AbortController`
+
+**Location**: [`clients/node/examples/order-pipeline/`](https://github.com/Joessst-Dev/queue-ti/tree/main/clients/node/examples/order-pipeline)
+
+```bash
+# From clients/node/ — requires: docker-compose up (from repo root)
+npm install
+npx ts-node --esm examples/order-pipeline/index.ts
+```
+
 ## Full Client Documentation
 
 For complete API reference and examples, see [clients/node/README.md](https://github.com/Joessst-Dev/queue-ti/tree/main/clients/node).

--- a/docs/clients/python.md
+++ b/docs/clients/python.md
@@ -373,6 +373,26 @@ The `AsyncAdminClient` covers:
 
 For complete examples and method signatures, see [clients/python/queueti/_admin.py](https://github.com/Joessst-Dev/queue-ti/tree/main/clients/python/queueti/_admin.py).
 
+## Sample Applications
+
+### Order Pipeline
+
+A self-contained end-to-end example demonstrating the full producer → consumer → ack lifecycle:
+
+- Client creation and consumer group registration via the admin REST API
+- Publishing messages with metadata
+- Streaming consumption with `concurrency=3`, ack on success, nack on failure (poison pill)
+- DLQ drain — batch-polls `orders.dlq` and acks dead-lettered messages
+- Graceful shutdown on SIGINT/SIGTERM via `asyncio.Event` + `loop.add_signal_handler`
+
+**Location**: [`clients/python/examples/order_pipeline/`](https://github.com/Joessst-Dev/queue-ti/tree/main/clients/python/examples/order_pipeline)
+
+```bash
+# From clients/python/ — requires: docker-compose up (from repo root)
+pip install -e ".[dev]"
+python examples/order_pipeline/main.py
+```
+
 ## Full Client Documentation
 
 For complete API reference and examples, see [clients/python/README.md](https://github.com/Joessst-Dev/queue-ti/tree/main/clients/python).


### PR DESCRIPTION
Closes #51.

## Summary

Adds a self-contained `order-pipeline` sample to each of the three main client libraries. Each sample demonstrates the full producer → consumer → ack lifecycle against a local `docker-compose` stack.

## What each sample covers

- Client creation (insecure mode for local dev)
- Consumer group registration via the admin REST API
- Publishing messages with metadata and a deduplication key
- Streaming consumption with configurable concurrency
- Ack on success, nack with reason on failure (poison pill simulation)
- DLQ drain — batch-polls `orders.dlq` and acks dead-lettered messages
- Graceful shutdown on SIGINT/SIGTERM

## Locations

| Client | Path | Run command |
|--------|------|-------------|
| Go | `clients/go-client/examples/order-pipeline/` | `go run .` |
| Node.js | `clients/node/examples/order-pipeline/` | `npx ts-node examples/order-pipeline/index.ts` |
| Python | `clients/python/examples/order_pipeline/` | `python examples/order_pipeline/main.py` |

## Validation

- Go: `go build ./...` — compiles clean
- Node.js: `tsc --noEmit --strict` — no type errors
- Python: `mypy` — no issues found in 1 source file