### PR TITLE
fix(docs): update C# client target from .NET 10 to .NET 8

### DIFF
--- a/docs/clients/csharp.md
+++ b/docs/clients/csharp.md
@@ -2,7 +2,7 @@
 
 [![NuGet](https://img.shields.io/nuget/v/QueueTi.Client)](https://www.nuget.org/packages/QueueTi.Client)
 
-A proto-first gRPC client library for queue-ti. Targets `.NET 10.0`.
+A proto-first gRPC client library for queue-ti. Targets `.NET 8.0`+.
 
 - **Repository**: [github.com/Joessst-Dev/queue-ti-csharp-client](https://github.com/Joessst-Dev/queue-ti-csharp-client)
 - **NuGet**: [nuget.org/packages/QueueTi.Client](https://www.nuget.org/packages/QueueTi.Client)


### PR DESCRIPTION
Closes #56.

## Summary

- Updates the C# client page description from `.NET 10.0` to `.NET 8.0`+
- Reflects the retargeting of `queue-ti-csharp-client` from `net10.0` to `net8.0` for Aspire 9.x compatibility (see Joessst-Dev/queue-ti-csharp-client#19)
- The `+` clarifies that `net8.0` assemblies are forward-compatible with .NET 9 and .NET 10 consumers