### PR TITLE
feat: add QueueTiAuth helper to Go, Node.js, and Python clients

### DIFF
--- a/clients/go-client/README.md
+++ b/clients/go-client/README.md
@@ -325,7 +325,46 @@ Returns the message to the queue. `reason` is stored as the failure string and i
 
 When the server has `auth.enabled = true`, every RPC call requires a valid JWT. Tokens are issued by the server's HTTP API and expire after 15 minutes.
 
-### Obtaining a token
+### Using QueueTiAuth (recommended)
+
+The `NewAuth` helper automatically checks if authentication is required and handles login and token refresh:
+
+```go
+auth, err := queueti.NewAuth("http://localhost:8080", "admin", "secret")
+if err != nil {
+    log.Fatal(err)
+}
+
+// Build dial options conditionally on whether auth is enabled
+opts := []queueti.DialOption{queueti.WithInsecure()}
+
+// If auth is required, add token and refresh
+if auth.Token() != "" {
+    opts = append(opts,
+        queueti.WithBearerToken(auth.Token()),
+        queueti.WithTokenRefresher(auth.Refresh),
+    )
+}
+
+client, err := queueti.Dial("localhost:50051", opts...)
+if err != nil {
+    log.Fatal(err)
+}
+defer client.Close()
+
+// For the admin client
+adminClient := queueti.NewAdminClient("http://localhost:8080",
+    queueti.WithAdminToken(auth.Token()),
+)
+```
+
+The `NewAuth` helper:
+1. Calls `GET /api/auth/status` to check if authentication is required
+2. If auth is disabled, returns a no-op instance with an empty token
+3. If auth is enabled, calls `POST /api/auth/login` with the provided credentials
+4. Exposes `Token()` for the current JWT and `Refresh(ctx)` which satisfies the `TokenRefresher` interface for automatic token refresh
+
+### Option 1 — Obtaining a token manually
 
 ```bash
 TOKEN=$(curl -s -X POST http://localhost:8080/api/auth/login \
@@ -334,7 +373,7 @@ TOKEN=$(curl -s -X POST http://localhost:8080/api/auth/login \
   | jq -r '.token')
 ```
 
-### Option 1 — Automatic refresh (recommended)
+### Option 2 — Automatic refresh with custom fetcher
 
 Pass an initial token and a `TokenRefresher` callback. The library decodes the JWT `exp` claim, sleeps until 60 seconds before expiry, and calls your callback to obtain a fresh token. The new token is applied to the next RPC call — no reconnection needed.
 
@@ -355,7 +394,7 @@ defer client.Close() // also stops the background refresh goroutine
 
 If the refresher returns an error, the library retries with exponential backoff (5 s → 60 s) and logs each failure. RPCs will start failing with `Unauthenticated` once the token expires, so ensure the refresher can recover.
 
-### Option 2 — Manual update
+### Option 3 — Manual update
 
 Call `client.SetToken` to swap the token on a live connection. The new token takes effect on the very next RPC call; no reconnection is needed.
 
@@ -373,7 +412,7 @@ if err := client.SetToken(newToken); err != nil {
 
 This is useful when token lifecycle is managed externally (e.g. a shared token store, a sidecar, or an existing refresh loop in your application).
 
-### Option 3 — Static token (short-lived processes)
+### Option 4 — Static token (short-lived processes)
 
 For scripts or batch jobs that complete within the 15-minute token window, a static token is sufficient:
 

--- a/clients/go-client/README.md
+++ b/clients/go-client/README.md
@@ -335,10 +335,7 @@ if err != nil {
     log.Fatal(err)
 }
 
-// Build dial options conditionally on whether auth is enabled
 opts := []queueti.DialOption{queueti.WithInsecure()}
-
-// If auth is required, add token and refresh
 if auth.Token() != "" {
     opts = append(opts,
         queueti.WithBearerToken(auth.Token()),
@@ -352,7 +349,6 @@ if err != nil {
 }
 defer client.Close()
 
-// For the admin client
 adminClient := queueti.NewAdminClient("http://localhost:8080",
     queueti.WithAdminToken(auth.Token()),
 )

--- a/clients/go-client/auth.go
+++ b/clients/go-client/auth.go
@@ -1,0 +1,153 @@
+package queueti
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Auth encapsulates the queue-ti authentication flow against the admin HTTP
+// API. It checks whether auth is required, performs the login, and implements
+// TokenRefresher so it can be wired directly into Dial options.
+//
+// When auth is disabled on the server, NewAuth returns an Auth whose Token()
+// is empty and whose Refresh method is a no-op.
+type Auth struct {
+	adminAddr string
+	username  string
+	password  string
+	httpClient *http.Client
+
+	mu    sync.RWMutex
+	token string // empty when auth is disabled
+}
+
+// NewAuth connects to adminAddr, checks whether auth is required, and — when
+// it is — performs a login with username/password to obtain a JWT.
+//
+// adminAddr should be the scheme+host+port of the admin API, e.g.
+// "http://localhost:8080". A trailing slash is stripped automatically.
+func NewAuth(adminAddr, username, password string) (*Auth, error) {
+	a := &Auth{
+		adminAddr:  strings.TrimRight(adminAddr, "/"),
+		username:   username,
+		password:   password,
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+	}
+
+	required, err := a.authRequired()
+	if err != nil {
+		return nil, fmt.Errorf("queue-ti auth: check auth status: %w", err)
+	}
+	if !required {
+		return a, nil
+	}
+
+	if err := a.login(); err != nil {
+		return nil, fmt.Errorf("queue-ti auth: login: %w", err)
+	}
+	return a, nil
+}
+
+// Token returns the current JWT, or an empty string when authentication is
+// disabled on the server.
+func (a *Auth) Token() string {
+	a.mu.RLock()
+	defer a.mu.RUnlock()
+	return a.token
+}
+
+// Refresh implements TokenRefresher. It re-authenticates with the server and
+// updates the stored token. When auth is disabled (Token() is empty) it is a
+// no-op and returns ("", nil).
+func (a *Auth) Refresh(_ context.Context) (string, error) {
+	if a.Token() == "" {
+		return "", nil
+	}
+	if err := a.login(); err != nil {
+		return "", fmt.Errorf("queue-ti auth: refresh: %w", err)
+	}
+	return a.Token(), nil
+}
+
+// authRequired calls GET /api/auth/status and returns true when the server
+// requires authentication.
+func (a *Auth) authRequired() (bool, error) {
+	req, err := http.NewRequest(http.MethodGet, a.adminAddr+"/api/auth/status", nil)
+	if err != nil {
+		return false, err
+	}
+	resp, err := a.httpClient.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return false, fmt.Errorf("read response body: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return false, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(raw))
+	}
+
+	var body struct {
+		AuthRequired bool `json:"auth_required"`
+	}
+	if err := json.Unmarshal(raw, &body); err != nil {
+		return false, fmt.Errorf("decode response: %w", err)
+	}
+	return body.AuthRequired, nil
+}
+
+// login calls POST /api/auth/login and stores the returned JWT.
+func (a *Auth) login() error {
+	payload, err := json.Marshal(map[string]string{
+		"username": a.username,
+		"password": a.password,
+	})
+	if err != nil {
+		return fmt.Errorf("marshal request body: %w", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, a.adminAddr+"/api/auth/login", bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := a.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("read response body: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(raw))
+	}
+
+	var body struct {
+		Token string `json:"token"`
+	}
+	if err := json.Unmarshal(raw, &body); err != nil {
+		return fmt.Errorf("decode response: %w", err)
+	}
+	if body.Token == "" {
+		return fmt.Errorf("server returned empty token")
+	}
+
+	a.mu.Lock()
+	a.token = body.Token
+	a.mu.Unlock()
+	return nil
+}

--- a/clients/go-client/auth.go
+++ b/clients/go-client/auth.go
@@ -19,9 +19,9 @@ import (
 // When auth is disabled on the server, NewAuth returns an Auth whose Token()
 // is empty and whose Refresh method is a no-op.
 type Auth struct {
-	adminAddr string
-	username  string
-	password  string
+	adminAddr  string
+	username   string
+	password   string
 	httpClient *http.Client
 
 	mu    sync.RWMutex
@@ -41,7 +41,7 @@ func NewAuth(adminAddr, username, password string) (*Auth, error) {
 		httpClient: &http.Client{Timeout: 30 * time.Second},
 	}
 
-	required, err := a.authRequired()
+	required, err := a.authRequired(context.Background())
 	if err != nil {
 		return nil, fmt.Errorf("queue-ti auth: check auth status: %w", err)
 	}
@@ -49,7 +49,7 @@ func NewAuth(adminAddr, username, password string) (*Auth, error) {
 		return a, nil
 	}
 
-	if err := a.login(); err != nil {
+	if err := a.login(context.Background()); err != nil {
 		return nil, fmt.Errorf("queue-ti auth: login: %w", err)
 	}
 	return a, nil
@@ -66,11 +66,11 @@ func (a *Auth) Token() string {
 // Refresh implements TokenRefresher. It re-authenticates with the server and
 // updates the stored token. When auth is disabled (Token() is empty) it is a
 // no-op and returns ("", nil).
-func (a *Auth) Refresh(_ context.Context) (string, error) {
+func (a *Auth) Refresh(ctx context.Context) (string, error) {
 	if a.Token() == "" {
 		return "", nil
 	}
-	if err := a.login(); err != nil {
+	if err := a.login(ctx); err != nil {
 		return "", fmt.Errorf("queue-ti auth: refresh: %w", err)
 	}
 	return a.Token(), nil
@@ -78,8 +78,8 @@ func (a *Auth) Refresh(_ context.Context) (string, error) {
 
 // authRequired calls GET /api/auth/status and returns true when the server
 // requires authentication.
-func (a *Auth) authRequired() (bool, error) {
-	req, err := http.NewRequest(http.MethodGet, a.adminAddr+"/api/auth/status", nil)
+func (a *Auth) authRequired(ctx context.Context) (bool, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, a.adminAddr+"/api/auth/status", nil)
 	if err != nil {
 		return false, err
 	}
@@ -107,7 +107,7 @@ func (a *Auth) authRequired() (bool, error) {
 }
 
 // login calls POST /api/auth/login and stores the returned JWT.
-func (a *Auth) login() error {
+func (a *Auth) login(ctx context.Context) error {
 	payload, err := json.Marshal(map[string]string{
 		"username": a.username,
 		"password": a.password,
@@ -116,7 +116,7 @@ func (a *Auth) login() error {
 		return fmt.Errorf("marshal request body: %w", err)
 	}
 
-	req, err := http.NewRequest(http.MethodPost, a.adminAddr+"/api/auth/login", bytes.NewReader(payload))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, a.adminAddr+"/api/auth/login", bytes.NewReader(payload))
 	if err != nil {
 		return err
 	}

--- a/clients/go-client/auth_test.go
+++ b/clients/go-client/auth_test.go
@@ -1,0 +1,173 @@
+package queueti_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+
+	queueti "github.com/Joessst-Dev/queue-ti/clients/go-client"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Auth", func() {
+	Describe("NewAuth", func() {
+		Context("when the server does not require auth", func() {
+			It("returns an Auth with an empty token without calling login", func() {
+				loginCalled := false
+				srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					switch r.URL.Path {
+					case "/api/auth/status":
+						w.Header().Set("Content-Type", "application/json")
+						json.NewEncoder(w).Encode(map[string]any{"auth_required": false})
+					case "/api/auth/login":
+						loginCalled = true
+						w.WriteHeader(http.StatusInternalServerError)
+					default:
+						w.WriteHeader(http.StatusNotFound)
+					}
+				}))
+				defer srv.Close()
+
+				auth, err := queueti.NewAuth(srv.URL, "user", "pass")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(auth.Token()).To(BeEmpty())
+				Expect(loginCalled).To(BeFalse())
+			})
+
+			It("strips a trailing slash from the admin address", func() {
+				srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					if r.URL.Path == "/api/auth/status" {
+						w.Header().Set("Content-Type", "application/json")
+						json.NewEncoder(w).Encode(map[string]any{"auth_required": false})
+					}
+				}))
+				defer srv.Close()
+
+				_, err := queueti.NewAuth(srv.URL+"/", "user", "pass")
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+
+		Context("when the server requires auth", func() {
+			It("returns an Auth with the token from the login response", func() {
+				srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					switch r.URL.Path {
+					case "/api/auth/status":
+						json.NewEncoder(w).Encode(map[string]any{"auth_required": true})
+					case "/api/auth/login":
+						var creds map[string]string
+						json.NewDecoder(r.Body).Decode(&creds)
+						Expect(creds["username"]).To(Equal("admin"))
+						Expect(creds["password"]).To(Equal("secret"))
+						json.NewEncoder(w).Encode(map[string]string{"token": "jwt-token-abc"})
+					}
+				}))
+				defer srv.Close()
+
+				auth, err := queueti.NewAuth(srv.URL, "admin", "secret")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(auth.Token()).To(Equal("jwt-token-abc"))
+			})
+
+			It("encodes credentials with JSON so special characters are safe", func() {
+				var capturedBody []byte
+				srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					switch r.URL.Path {
+					case "/api/auth/status":
+						json.NewEncoder(w).Encode(map[string]any{"auth_required": true})
+					case "/api/auth/login":
+						capturedBody, _ = json.Marshal(nil)
+						var body map[string]string
+						json.NewDecoder(r.Body).Decode(&body)
+						capturedBody, _ = json.Marshal(body)
+						json.NewEncoder(w).Encode(map[string]string{"token": "tok"})
+					}
+				}))
+				defer srv.Close()
+
+				_, err := queueti.NewAuth(srv.URL, `user"name`, `p\a"ss`)
+				Expect(err).NotTo(HaveOccurred())
+				var body map[string]string
+				json.Unmarshal(capturedBody, &body)
+				Expect(body["username"]).To(Equal(`user"name`))
+				Expect(body["password"]).To(Equal(`p\a"ss`))
+			})
+
+			It("returns an error when login fails", func() {
+				srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					switch r.URL.Path {
+					case "/api/auth/status":
+						w.Header().Set("Content-Type", "application/json")
+						json.NewEncoder(w).Encode(map[string]any{"auth_required": true})
+					case "/api/auth/login":
+						w.WriteHeader(http.StatusUnauthorized)
+						w.Write([]byte(`{"error":"invalid credentials"}`))
+					}
+				}))
+				defer srv.Close()
+
+				_, err := queueti.NewAuth(srv.URL, "bad", "creds")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("login"))
+			})
+		})
+
+		Context("when the status endpoint is unreachable", func() {
+			It("returns an error", func() {
+				_, err := queueti.NewAuth("http://127.0.0.1:1", "u", "p")
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("check auth status"))
+			})
+		})
+	})
+
+	Describe("Refresh", func() {
+		Context("when auth is disabled (empty token)", func() {
+			It("is a no-op and returns an empty string", func() {
+				srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					json.NewEncoder(w).Encode(map[string]any{"auth_required": false})
+				}))
+				defer srv.Close()
+
+				auth, err := queueti.NewAuth(srv.URL, "u", "p")
+				Expect(err).NotTo(HaveOccurred())
+
+				tok, err := auth.Refresh(context.Background())
+				Expect(err).NotTo(HaveOccurred())
+				Expect(tok).To(BeEmpty())
+			})
+		})
+
+		Context("when auth is enabled", func() {
+			It("re-authenticates and returns the new token", func() {
+				callCount := 0
+				srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					switch r.URL.Path {
+					case "/api/auth/status":
+						json.NewEncoder(w).Encode(map[string]any{"auth_required": true})
+					case "/api/auth/login":
+						callCount++
+						json.NewEncoder(w).Encode(map[string]string{"token": "refreshed-token"})
+					}
+				}))
+				defer srv.Close()
+
+				auth, err := queueti.NewAuth(srv.URL, "admin", "secret")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(callCount).To(Equal(1))
+
+				tok, err := auth.Refresh(context.Background())
+				Expect(err).NotTo(HaveOccurred())
+				Expect(tok).To(Equal("refreshed-token"))
+				Expect(callCount).To(Equal(2))
+			})
+		})
+	})
+})

--- a/clients/go-client/auth_test.go
+++ b/clients/go-client/auth_test.go
@@ -81,7 +81,6 @@ var _ = Describe("Auth", func() {
 					case "/api/auth/status":
 						json.NewEncoder(w).Encode(map[string]any{"auth_required": true})
 					case "/api/auth/login":
-						capturedBody, _ = json.Marshal(nil)
 						var body map[string]string
 						json.NewDecoder(r.Body).Decode(&body)
 						capturedBody, _ = json.Marshal(body)
@@ -123,6 +122,34 @@ var _ = Describe("Auth", func() {
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("check auth status"))
 			})
+		})
+	})
+
+	Describe("Refresh context propagation", func() {
+		It("respects a cancelled context and does not perform the HTTP call", func() {
+			loginCalled := false
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch r.URL.Path {
+				case "/api/auth/status":
+					json.NewEncoder(w).Encode(map[string]any{"auth_required": true})
+				case "/api/auth/login":
+					loginCalled = true
+					json.NewEncoder(w).Encode(map[string]string{"token": "tok"})
+				}
+			}))
+			defer srv.Close()
+
+			auth, err := queueti.NewAuth(srv.URL, "admin", "secret")
+			Expect(err).NotTo(HaveOccurred())
+			loginCalled = false // reset after initial login
+
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel() // cancel before calling Refresh
+
+			_, err = auth.Refresh(ctx)
+			Expect(err).To(HaveOccurred())
+			Expect(loginCalled).To(BeFalse())
 		})
 	})
 

--- a/clients/go-client/examples/order-pipeline/main.go
+++ b/clients/go-client/examples/order-pipeline/main.go
@@ -7,12 +7,11 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
-	"net/http"
 	"os"
 	"os/signal"
-	"strings"
 	"syscall"
 	"time"
 
@@ -38,13 +37,28 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 
-	client, err := queueti.Dial(grpcAddr, queueti.WithInsecure())
+	auth, err := queueti.NewAuth(adminAddr, envOr("QUEUETI_USERNAME", "admin"), envOr("QUEUETI_PASSWORD", "secret"))
+	if err != nil {
+		log.Fatalf("auth: %v", err)
+	}
+
+	dialOpts := []queueti.DialOption{queueti.WithInsecure()}
+	if auth.Token() != "" {
+		dialOpts = append(dialOpts,
+			queueti.WithBearerToken(auth.Token()),
+			queueti.WithTokenRefresher(auth.Refresh),
+		)
+	}
+
+	client, err := queueti.Dial(grpcAddr, dialOpts...)
 	if err != nil {
 		log.Fatalf("dial: %v", err)
 	}
 	defer client.Close()
 
-	if err := registerConsumerGroup(ctx); err != nil {
+	admin := queueti.NewAdminClient(adminAddr, queueti.WithAdminToken(auth.Token()))
+
+	if err := registerConsumerGroup(ctx, admin); err != nil {
 		log.Fatalf("register consumer group: %v", err)
 	}
 
@@ -53,24 +67,18 @@ func main() {
 	consume(ctx, client)
 }
 
-// registerConsumerGroup calls the admin REST API to ensure the consumer group exists.
-func registerConsumerGroup(ctx context.Context) error {
-	body := fmt.Sprintf(`{"consumer_group":%q}`, consumerGroup)
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
-		fmt.Sprintf("%s/api/topics/%s/consumer-groups", adminAddr, topic),
-		strings.NewReader(body))
-	if err != nil {
-		return err
+func envOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
 	}
-	req.Header.Set("Content-Type", "application/json")
+	return fallback
+}
 
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return err
-	}
-	resp.Body.Close()
-	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusConflict {
-		return fmt.Errorf("unexpected status %d", resp.StatusCode)
+// registerConsumerGroup ensures the consumer group exists via the admin API.
+func registerConsumerGroup(ctx context.Context, admin *queueti.AdminClient) error {
+	err := admin.RegisterConsumerGroup(ctx, topic, consumerGroup)
+	if err != nil && !errors.Is(err, queueti.ErrConflict) {
+		return fmt.Errorf("register consumer group: %w", err)
 	}
 	log.Printf("consumer group %q ready", consumerGroup)
 	return nil

--- a/clients/node/README.md
+++ b/clients/node/README.md
@@ -355,7 +355,33 @@ Returns the message to the queue. `reason` is stored as the failure string and i
 
 When the server has `auth.enabled = true`, every RPC call requires a valid JWT. Tokens are issued by the server's HTTP API and expire after 15 minutes.
 
-### Obtaining a token
+### Using QueueTiAuth (recommended)
+
+The `QueueTiAuth` helper automatically checks if authentication is required and handles login and token refresh:
+
+```typescript
+import { connect, AdminClient, QueueTiAuth } from '@queue-ti/client'
+
+const auth = await QueueTiAuth.login('http://localhost:8080', 'admin', 'secret')
+
+const client = await connect('localhost:50051', {
+  insecure: true,
+  token: auth.token ?? undefined,
+  tokenRefresher: auth.refresh,
+})
+
+const admin = new AdminClient('http://localhost:8080', {
+  token: auth.token ?? undefined,
+})
+```
+
+The `QueueTiAuth` helper:
+1. Calls `GET /api/auth/status` to check if authentication is required
+2. If auth is disabled, returns a no-op instance with a null token
+3. If auth is enabled, calls `POST /api/auth/login` with the provided credentials
+4. Exposes `.token` (string or null) for the current JWT and `.refresh` (arrow function) which satisfies the `ConnectOptions.tokenRefresher` interface for automatic token refresh
+
+### Option 1 — Obtaining a token manually
 
 ```bash
 TOKEN=$(curl -s -X POST http://localhost:8080/api/auth/login \
@@ -364,7 +390,7 @@ TOKEN=$(curl -s -X POST http://localhost:8080/api/auth/login \
   | jq -r '.token')
 ```
 
-### Option 1 — Automatic refresh (recommended)
+### Option 2 — Automatic refresh with custom fetcher
 
 Pass an initial token and a `tokenRefresher` callback. The library decodes the JWT `exp` claim, sleeps until 60 seconds before expiry, and calls your callback to obtain a fresh token. The new token is applied to the next RPC call — no reconnection needed.
 
@@ -387,7 +413,7 @@ const client = await connect('localhost:50051', {
 
 If the refresher returns an error, the library retries with exponential backoff (5 s → 60 s) and logs each failure. RPCs will start failing with `Unauthenticated` once the token expires, so ensure the refresher can recover.
 
-### Option 2 — Manual update
+### Option 3 — Manual update
 
 Call `client.setToken()` to swap the token on a live connection. The new token takes effect on the very next RPC call; no reconnection is needed.
 
@@ -403,7 +429,7 @@ client.setToken(newToken)
 
 This is useful when token lifecycle is managed externally (e.g. a shared token store, a sidecar, or an existing refresh loop in your application).
 
-### Option 3 — Static token (short-lived processes)
+### Option 4 — Static token (short-lived processes)
 
 For scripts or jobs that complete within the 15-minute token window, a static token is sufficient:
 

--- a/clients/node/examples/order-pipeline/index.ts
+++ b/clients/node/examples/order-pipeline/index.ts
@@ -2,7 +2,7 @@
  * Order pipeline — demonstrates the full producer → consumer → ack lifecycle
  * against a local queue-ti instance.
  *
- * Run: npx ts-node index.ts (requires docker-compose up)
+ * Run: npx ts-node --transpile-only examples/order-pipeline/index.ts (requires docker-compose up)
  */
 
 import { connect, AdminClient, QueueTiAuth } from '../../src'
@@ -92,25 +92,23 @@ async function consume(auth: QueueTiAuth, controller: AbortController): Promise<
 
     if (order.poison) {
       console.log(`nack ${msg.id}: poison pill detected (retry ${msg.retryCount})`)
-      await msg.nack('poison pill')
-      return
+      throw new Error('poison pill')
     }
 
     console.log(`ack ${msg.id}: processed order ${order.id} — ${order.amount}×${order.item}`)
-    await msg.ack()
   }
 
   await consumer.consume(handler)
   client.close()
 }
 
-async function drainDLQ(auth: QueueTiAuth): Promise<void> {
+async function drainDLQ(auth: QueueTiAuth, controller: AbortController): Promise<void> {
   const client = await connect(GRPC_ADDR, {
     insecure: true,
     token: auth.token ?? undefined,
     tokenRefresher: auth.refresh,
   })
-  const consumer = client.consumer(DLQ_TOPIC, { consumerGroup: CONSUMER_GROUP })
+  const consumer = client.consumer(DLQ_TOPIC, { consumerGroup: CONSUMER_GROUP, signal: controller.signal })
 
   console.log(`draining DLQ "${DLQ_TOPIC}"`)
 
@@ -141,7 +139,7 @@ async function main(): Promise<void> {
   await registerConsumerGroup(auth)
 
   void produce(auth, controller)
-  void drainDLQ(auth)
+  void drainDLQ(auth, controller)
   await consume(auth, controller)
 }
 

--- a/clients/node/examples/order-pipeline/index.ts
+++ b/clients/node/examples/order-pipeline/index.ts
@@ -5,7 +5,7 @@
  * Run: npx ts-node index.ts (requires docker-compose up)
  */
 
-import { connect, AdminClient } from '../../src'
+import { connect, AdminClient, QueueTiAuth } from '../../src'
 import type { Message } from '../../src/message'
 import type { MessageHandler } from '../../src/consumer'
 
@@ -14,6 +14,8 @@ const ADMIN_URL = 'http://localhost:8080'
 const TOPIC = 'orders'
 const DLQ_TOPIC = 'orders.dlq'
 const CONSUMER_GROUP = 'fulfillment'
+const USERNAME = process.env.QUEUETI_USERNAME ?? 'admin'
+const PASSWORD = process.env.QUEUETI_PASSWORD ?? 'secret'
 
 interface Order {
   id: string
@@ -34,8 +36,8 @@ async function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
-async function registerConsumerGroup(): Promise<void> {
-  const admin = new AdminClient(ADMIN_URL)
+async function registerConsumerGroup(auth: QueueTiAuth): Promise<void> {
+  const admin = new AdminClient(ADMIN_URL, { token: auth.token ?? undefined })
   try {
     await admin.registerConsumerGroup(TOPIC, CONSUMER_GROUP)
     console.log(`consumer group "${CONSUMER_GROUP}" registered`)
@@ -49,8 +51,12 @@ async function registerConsumerGroup(): Promise<void> {
   }
 }
 
-async function produce(controller: AbortController): Promise<void> {
-  const client = await connect(GRPC_ADDR, { insecure: true })
+async function produce(auth: QueueTiAuth, controller: AbortController): Promise<void> {
+  const client = await connect(GRPC_ADDR, {
+    insecure: true,
+    token: auth.token ?? undefined,
+    tokenRefresher: auth.refresh,
+  })
   const producer = client.producer()
 
   for (const order of orders) {
@@ -67,8 +73,12 @@ async function produce(controller: AbortController): Promise<void> {
   client.close()
 }
 
-async function consume(controller: AbortController): Promise<void> {
-  const client = await connect(GRPC_ADDR, { insecure: true })
+async function consume(auth: QueueTiAuth, controller: AbortController): Promise<void> {
+  const client = await connect(GRPC_ADDR, {
+    insecure: true,
+    token: auth.token ?? undefined,
+    tokenRefresher: auth.refresh,
+  })
   const consumer = client.consumer(TOPIC, {
     consumerGroup: CONSUMER_GROUP,
     concurrency: 3,
@@ -94,8 +104,12 @@ async function consume(controller: AbortController): Promise<void> {
   client.close()
 }
 
-async function drainDLQ(controller: AbortController): Promise<void> {
-  const client = await connect(GRPC_ADDR, { insecure: true })
+async function drainDLQ(auth: QueueTiAuth): Promise<void> {
+  const client = await connect(GRPC_ADDR, {
+    insecure: true,
+    token: auth.token ?? undefined,
+    tokenRefresher: auth.refresh,
+  })
   const consumer = client.consumer(DLQ_TOPIC, { consumerGroup: CONSUMER_GROUP })
 
   console.log(`draining DLQ "${DLQ_TOPIC}"`)
@@ -114,6 +128,8 @@ async function drainDLQ(controller: AbortController): Promise<void> {
 }
 
 async function main(): Promise<void> {
+  const auth = await QueueTiAuth.login(ADMIN_URL, USERNAME, PASSWORD)
+
   const controller = new AbortController()
 
   process.on('SIGINT', () => {
@@ -122,11 +138,11 @@ async function main(): Promise<void> {
   })
   process.on('SIGTERM', () => controller.abort())
 
-  await registerConsumerGroup()
+  await registerConsumerGroup(auth)
 
-  void produce(controller)
-  void drainDLQ(controller)
-  await consume(controller)
+  void produce(auth, controller)
+  void drainDLQ(auth)
+  await consume(auth, controller)
 }
 
 main().catch((err) => {

--- a/clients/node/package-lock.json
+++ b/clients/node/package-lock.json
@@ -14,9 +14,23 @@
       "devDependencies": {
         "@types/node": "^22.0.0",
         "eslint": "^9.39.4",
+        "ts-node": "^10.9.2",
         "typescript": "^5.8.0",
         "typescript-eslint": "^8.59.1",
         "vitest": "^3.0.0"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -720,12 +734,33 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
     },
     "node_modules/@js-sdsl/ordered-map": {
       "version": "4.4.2",
@@ -1150,6 +1185,34 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -1612,6 +1675,19 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.15.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
@@ -1652,6 +1728,13 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -1791,6 +1874,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1840,6 +1930,16 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/diff": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.4.tgz",
+      "integrity": "sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -2435,6 +2535,13 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -2944,6 +3051,50 @@
         "typescript": ">=4.8.4"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -3010,6 +3161,13 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/vite": {
       "version": "7.3.2",
@@ -3276,6 +3434,16 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/clients/node/package.json
+++ b/clients/node/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "@types/node": "^22.0.0",
     "eslint": "^9.39.4",
+    "ts-node": "^10.9.2",
     "typescript": "^5.8.0",
     "typescript-eslint": "^8.59.1",
     "vitest": "^3.0.0"

--- a/clients/node/src/__tests__/auth.spec.ts
+++ b/clients/node/src/__tests__/auth.spec.ts
@@ -115,6 +115,7 @@ describe('QueueTiAuth', () => {
 
       const newToken = await auth.refresh()
       expect(newToken).toBe('refreshed-token')
+      expect(auth.token).toBe('refreshed-token')
     })
   })
 })

--- a/clients/node/src/__tests__/auth.spec.ts
+++ b/clients/node/src/__tests__/auth.spec.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { QueueTiAuth } from '../auth'
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+beforeEach(() => {
+  mockFetch.mockReset()
+})
+
+describe('QueueTiAuth', () => {
+  describe('login()', () => {
+    describe('when auth is not required', () => {
+      it('returns an instance with null token without calling login', async () => {
+        mockFetch.mockResolvedValueOnce(jsonResponse({ auth_required: false }))
+
+        const auth = await QueueTiAuth.login('http://localhost:8080', 'user', 'pass')
+
+        expect(auth.token).toBeNull()
+        expect(mockFetch).toHaveBeenCalledTimes(1)
+        expect(mockFetch.mock.calls[0][0]).toContain('/api/auth/status')
+      })
+
+      it('strips a trailing slash from adminAddr', async () => {
+        mockFetch.mockResolvedValueOnce(jsonResponse({ auth_required: false }))
+
+        await QueueTiAuth.login('http://localhost:8080/', 'u', 'p')
+
+        expect(mockFetch.mock.calls[0][0]).toBe('http://localhost:8080/api/auth/status')
+      })
+    })
+
+    describe('when auth is required', () => {
+      it('returns an instance with the token from the login response', async () => {
+        mockFetch
+          .mockResolvedValueOnce(jsonResponse({ auth_required: true }))
+          .mockResolvedValueOnce(jsonResponse({ token: 'jwt-abc' }))
+
+        const auth = await QueueTiAuth.login('http://localhost:8080', 'admin', 'secret')
+
+        expect(auth.token).toBe('jwt-abc')
+        expect(mockFetch).toHaveBeenCalledTimes(2)
+      })
+
+      it('sends credentials as JSON in the login body', async () => {
+        mockFetch
+          .mockResolvedValueOnce(jsonResponse({ auth_required: true }))
+          .mockResolvedValueOnce(jsonResponse({ token: 'tok' }))
+
+        await QueueTiAuth.login('http://localhost:8080', 'my"user', 'p\\a"ss')
+
+        const [url, init] = mockFetch.mock.calls[1]
+        expect(url).toContain('/api/auth/login')
+        const body = JSON.parse(init.body as string)
+        expect(body.username).toBe('my"user')
+        expect(body.password).toBe('p\\a"ss')
+      })
+
+      it('throws when the status endpoint returns a non-2xx response', async () => {
+        mockFetch.mockResolvedValueOnce(new Response('Internal error', { status: 500 }))
+
+        await expect(QueueTiAuth.login('http://localhost:8080', 'u', 'p')).rejects.toThrow(
+          /check auth status.*500/,
+        )
+      })
+
+      it('throws when login returns a non-2xx response', async () => {
+        mockFetch
+          .mockResolvedValueOnce(jsonResponse({ auth_required: true }))
+          .mockResolvedValueOnce(new Response('Unauthorized', { status: 401 }))
+
+        await expect(QueueTiAuth.login('http://localhost:8080', 'bad', 'creds')).rejects.toThrow(
+          /login.*401/,
+        )
+      })
+
+      it('throws when the login response has an empty token', async () => {
+        mockFetch
+          .mockResolvedValueOnce(jsonResponse({ auth_required: true }))
+          .mockResolvedValueOnce(jsonResponse({ token: '' }))
+
+        await expect(QueueTiAuth.login('http://localhost:8080', 'u', 'p')).rejects.toThrow(
+          /empty token/,
+        )
+      })
+    })
+  })
+
+  describe('refresh()', () => {
+    it('returns empty string when auth is disabled', async () => {
+      mockFetch.mockResolvedValueOnce(jsonResponse({ auth_required: false }))
+
+      const auth = await QueueTiAuth.login('http://localhost:8080', 'u', 'p')
+      const result = await auth.refresh()
+
+      expect(result).toBe('')
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+    })
+
+    it('re-authenticates and returns the new token', async () => {
+      mockFetch
+        .mockResolvedValueOnce(jsonResponse({ auth_required: true }))
+        .mockResolvedValueOnce(jsonResponse({ token: 'initial-token' }))
+        .mockResolvedValueOnce(jsonResponse({ token: 'refreshed-token' }))
+
+      const auth = await QueueTiAuth.login('http://localhost:8080', 'admin', 'secret')
+      expect(auth.token).toBe('initial-token')
+
+      const newToken = await auth.refresh()
+      expect(newToken).toBe('refreshed-token')
+    })
+  })
+})

--- a/clients/node/src/auth.ts
+++ b/clients/node/src/auth.ts
@@ -1,7 +1,7 @@
 import type { TokenRefresher } from './options'
 
 export class QueueTiAuth {
-  readonly token: string | null
+  token: string | null
   private readonly adminAddr: string
   private readonly username: string
   private readonly password: string
@@ -43,14 +43,17 @@ export class QueueTiAuth {
   }
 
   /**
-   * Implements the TokenRefresher interface. Re-authenticates with the server
-   * and returns the new token. When auth is disabled, returns an empty string.
+   * Implements the TokenRefresher interface. Re-authenticates with the server,
+   * updates the stored token, and returns the new token. When auth is disabled,
+   * returns an empty string.
    */
   readonly refresh: TokenRefresher = async (): Promise<string> => {
     if (this.token === null) {
       return ''
     }
-    return QueueTiAuth._doLogin(this.adminAddr, this.username, this.password)
+    const newToken = await QueueTiAuth._doLogin(this.adminAddr, this.username, this.password)
+    this.token = newToken
+    return newToken
   }
 
   private static async _doLogin(base: string, username: string, password: string): Promise<string> {

--- a/clients/node/src/auth.ts
+++ b/clients/node/src/auth.ts
@@ -1,0 +1,72 @@
+import type { TokenRefresher } from './options'
+
+export class QueueTiAuth {
+  readonly token: string | null
+  private readonly adminAddr: string
+  private readonly username: string
+  private readonly password: string
+
+  private constructor(
+    adminAddr: string,
+    username: string,
+    password: string,
+    token: string | null,
+  ) {
+    this.adminAddr = adminAddr
+    this.username = username
+    this.password = password
+    this.token = token
+  }
+
+  /**
+   * Checks whether auth is required on the server, and — when it is —
+   * performs a login with username/password to obtain a JWT.
+   *
+   * @param adminAddr Base URL of the admin API, e.g. "http://localhost:8080".
+   *                  A trailing slash is stripped automatically.
+   */
+  static async login(adminAddr: string, username: string, password: string): Promise<QueueTiAuth> {
+    const base = adminAddr.replace(/\/+$/, '')
+
+    const statusRes = await fetch(`${base}/api/auth/status`)
+    if (!statusRes.ok) {
+      throw new Error(`queue-ti auth: check auth status: HTTP ${statusRes.status}`)
+    }
+    const status = (await statusRes.json()) as { auth_required: boolean }
+
+    if (!status.auth_required) {
+      return new QueueTiAuth(base, username, password, null)
+    }
+
+    const token = await QueueTiAuth._doLogin(base, username, password)
+    return new QueueTiAuth(base, username, password, token)
+  }
+
+  /**
+   * Implements the TokenRefresher interface. Re-authenticates with the server
+   * and returns the new token. When auth is disabled, returns an empty string.
+   */
+  readonly refresh: TokenRefresher = async (): Promise<string> => {
+    if (this.token === null) {
+      return ''
+    }
+    return QueueTiAuth._doLogin(this.adminAddr, this.username, this.password)
+  }
+
+  private static async _doLogin(base: string, username: string, password: string): Promise<string> {
+    const res = await fetch(`${base}/api/auth/login`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password }),
+    })
+    if (!res.ok) {
+      const text = await res.text()
+      throw new Error(`queue-ti auth: login: HTTP ${res.status}: ${text}`)
+    }
+    const body = (await res.json()) as { token: string }
+    if (!body.token) {
+      throw new Error('queue-ti auth: login: server returned empty token')
+    }
+    return body.token
+  }
+}

--- a/clients/node/src/client.ts
+++ b/clients/node/src/client.ts
@@ -1,5 +1,6 @@
 import * as protoLoader from '@grpc/proto-loader'
 import * as grpc from '@grpc/grpc-js'
+import fs from 'fs'
 import path from 'path'
 import { ConnectOptions, ConsumerOptions, TokenRefresher } from './options'
 import { TokenStore, parseTokenExpiry } from './token-store'
@@ -7,8 +8,11 @@ import { sleepUntilOrAbort } from './internal/sleep'
 import { Producer, ProducerStub } from './producer'
 import { Consumer, ConsumerStub } from './consumer'
 
-// Proto is copied into dist/ by the build script so the package is self-contained.
-const PROTO_PATH = path.join(__dirname, 'queue.proto')
+// Proto is copied into dist/ by the build script. When running from source via
+// ts-node, fall back to the proto file in the repo root.
+const PROTO_PATH = fs.existsSync(path.join(__dirname, 'queue.proto'))
+  ? path.join(__dirname, 'queue.proto')
+  : path.join(__dirname, '../../../proto/queue.proto')
 
 const packageDef = protoLoader.loadSync(PROTO_PATH, {
   keepCase: false,
@@ -119,19 +123,35 @@ export async function connect(address: string, options?: ConnectOptions): Promis
   }
 
   let store: TokenStore | null = null
-  let callCredentials: grpc.CallCredentials | undefined
+  const channelOptions: grpc.ChannelOptions = {}
 
   if (options?.token) {
     store = new TokenStore(options.token)
-    callCredentials = grpc.credentials.createFromMetadataGenerator((_params, callback) => {
-      const meta = new grpc.Metadata()
-      meta.add('authorization', `Bearer ${store!.get()}`)
-      callback(null, meta)
-    })
-    credentials = grpc.credentials.combineChannelCredentials(credentials, callCredentials)
+
+    if (options.insecure) {
+      // grpc-js forbids composing call credentials with insecure channel credentials.
+      // Use a channel interceptor to inject the Authorization header instead.
+      channelOptions.interceptors = [
+        (interceptorOptions: grpc.InterceptorOptions, nextCall: grpc.NextCall) => {
+          return new grpc.InterceptingCall(nextCall(interceptorOptions), {
+            start(metadata, listener, next) {
+              metadata.add('authorization', `Bearer ${store!.get()}`)
+              next(metadata, listener)
+            },
+          })
+        },
+      ]
+    } else {
+      const callCredentials = grpc.credentials.createFromMetadataGenerator((_params, callback) => {
+        const meta = new grpc.Metadata()
+        meta.add('authorization', `Bearer ${store!.get()}`)
+        callback(null, meta)
+      })
+      credentials = grpc.credentials.combineChannelCredentials(credentials, callCredentials)
+    }
   }
 
-  const stub = new proto.queue.QueueService(address, credentials) as unknown
+  const stub = new proto.queue.QueueService(address, credentials, channelOptions) as unknown
 
   return new Client(stub, store, options?.tokenRefresher)
 }

--- a/clients/node/src/index.ts
+++ b/clients/node/src/index.ts
@@ -12,3 +12,4 @@ export type {
 } from './options'
 export { AdminClient, AdminError } from './admin'
 export type { AdminOptions, TopicConfig, TopicConfigInput, TopicSchema, TopicStat } from './admin'
+export { QueueTiAuth } from './auth'

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -170,6 +170,108 @@ All fields are optional.
 | `token_refresher` | `Callable[[], Awaitable[str]] \| None` | Async function to refresh the token before expiry |
 | `insecure` | `bool` | Disable TLS (for development only; default: `False`) |
 
+## Authentication
+
+When the server has `auth.enabled = true`, every RPC call requires a valid JWT. Tokens are issued by the server's HTTP API and expire after 15 minutes.
+
+### Using QueueTiAuth (recommended)
+
+The `QueueTiAuth` helper automatically checks if authentication is required and handles login and token refresh:
+
+```python
+import asyncio
+import queueti
+
+auth = queueti.QueueTiAuth.login("http://localhost:8080", "admin", "secret")
+
+async def main():
+    opts = queueti.ConnectOptions(
+        token=auth.token,
+        token_refresher=auth.async_refresh,
+    )
+    async with await queueti.connect("localhost:50051", opts) as client:
+        producer = client.producer()
+        msg_id = await producer.publish("orders", b"...")
+        print(f"Published: {msg_id}")
+
+    admin = queueti.AsyncAdminClient(
+        "http://localhost:8080",
+        queueti.AdminOptions(token=auth.token),
+    )
+    configs = await admin.list_topic_configs()
+    await admin.close()
+
+asyncio.run(main())
+```
+
+The `QueueTiAuth` helper:
+1. Calls `GET /api/auth/status` to check if authentication is required
+2. If auth is disabled, returns a no-op instance with a null token
+3. If auth is enabled, calls `POST /api/auth/login` with the provided credentials
+4. Exposes `.token` (str or None) for the current JWT and `.async_refresh()` (async callable) which satisfies the `ConnectOptions.token_refresher` interface for automatic token refresh
+
+### Option 1 — Obtaining a token manually
+
+```bash
+TOKEN=$(curl -s -X POST http://localhost:8080/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"username":"admin","password":"secret"}' \
+  | jq -r '.token')
+```
+
+### Option 2 — Automatic refresh with custom fetcher
+
+When your token expires, you can provide a refresher function to obtain a new token automatically:
+
+```python
+from queueti import connect, ConnectOptions
+
+async def refresh_token() -> str:
+    # Fetch a new token (e.g., from your auth service)
+    new_token = await fetch_fresh_token()
+    return new_token
+
+client = await connect(
+    "localhost:50051",
+    options=ConnectOptions(
+        token="initial-token",
+        token_refresher=refresh_token,
+    ),
+)
+
+# Token will refresh automatically before expiry
+```
+
+### Option 3 — Manual update
+
+Call `client.set_token()` to swap the token on a live connection. The new token takes effect on the very next RPC call; no reconnection is needed.
+
+```python
+client = await connect(
+    "localhost:50051",
+    options=ConnectOptions(token="initial-token"),
+)
+
+# Later, when you have a fresh token:
+client.set_token("new-token")
+```
+
+This is useful when token lifecycle is managed externally (e.g. a shared token store, a sidecar, or an existing refresh loop in your application).
+
+### Option 4 — Static token (short-lived processes)
+
+For scripts or batch jobs that complete within the 15-minute token window, a static token is sufficient:
+
+```python
+from queueti import connect, ConnectOptions
+import os
+
+client = await connect(
+    "localhost:50051",
+    options=ConnectOptions(token=os.getenv("QUEUETI_TOKEN")),
+)
+```
+
 ## Producer API
 
 ### AsyncProducer.publish()

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -189,26 +189,47 @@ async def main():
         token=auth.token,
         token_refresher=auth.async_refresh,
     )
-    async with await queueti.connect("localhost:50051", opts) as client:
+    client = await queueti.connect("localhost:50051", opts)
+    try:
         producer = client.producer()
         msg_id = await producer.publish("orders", b"...")
         print(f"Published: {msg_id}")
+    finally:
+        await client.close()
 
-    admin = queueti.AsyncAdminClient(
+    async with queueti.AsyncAdminClient(
         "http://localhost:8080",
         queueti.AdminOptions(token=auth.token),
-    )
-    configs = await admin.list_topic_configs()
-    await admin.close()
+    ) as admin:
+        configs = await admin.list_topic_configs()
 
 asyncio.run(main())
+```
+
+For the synchronous client, use `connect_sync` and `refresh()` (the sync variant of `async_refresh()`):
+
+```python
+import queueti
+
+auth = queueti.QueueTiAuth.login("http://localhost:8080", "admin", "secret")
+
+client = queueti.connect_sync("localhost:50051", queueti.ConnectOptions(
+    token=auth.token,
+    token_refresher=auth.async_refresh,
+))
+try:
+    producer = client.producer()
+    msg_id = producer.publish("orders", b"...")
+    print(f"Published: {msg_id}")
+finally:
+    client.close()
 ```
 
 The `QueueTiAuth` helper:
 1. Calls `GET /api/auth/status` to check if authentication is required
 2. If auth is disabled, returns a no-op instance with a null token
 3. If auth is enabled, calls `POST /api/auth/login` with the provided credentials
-4. Exposes `.token` (str or None) for the current JWT and `.async_refresh()` (async callable) which satisfies the `ConnectOptions.token_refresher` interface for automatic token refresh
+4. Exposes `.token` (str or None) for the current JWT, `.async_refresh()` for async clients, and `.refresh()` for sync clients
 
 ### Option 1 — Obtaining a token manually
 

--- a/clients/python/examples/order_pipeline/main.py
+++ b/clients/python/examples/order_pipeline/main.py
@@ -108,11 +108,9 @@ async def consume(auth: QueueTiAuth, stop: asyncio.Event) -> None:
 
         if order.poison:
             log.info("nack %s: poison pill detected (retry %d)", msg.id, msg.retry_count)
-            await msg.nack("poison pill")
-            return
+            raise ValueError("poison pill")
 
         log.info("ack %s: processed order %s — %d×%s", msg.id, order.id, order.amount, order.item)
-        await msg.ack()
 
     consume_task = asyncio.create_task(consumer.consume(handler))
     await stop.wait()
@@ -161,10 +159,13 @@ async def main() -> None:
 
     await register_consumer_group(auth)
 
-    async with asyncio.TaskGroup() as tg:
-        tg.create_task(produce(auth, stop))
-        tg.create_task(drain_dlq(auth))
-        tg.create_task(consume(auth, stop))
+    produce_task = asyncio.create_task(produce(auth, stop))
+    drain_task = asyncio.create_task(drain_dlq(auth))
+
+    await consume(auth, stop)
+
+    drain_task.cancel()
+    await asyncio.gather(produce_task, drain_task, return_exceptions=True)
 
 
 if __name__ == "__main__":

--- a/clients/python/examples/order_pipeline/main.py
+++ b/clients/python/examples/order_pipeline/main.py
@@ -11,9 +11,11 @@ import asyncio
 import dataclasses
 import json
 import logging
+import os
 import signal
 
 from queueti import (
+    AdminOptions,
     AsyncAdminClient,
     AdminError,
     BatchOptions,
@@ -21,6 +23,7 @@ from queueti import (
     ConsumerOptions,
     Message,
     PublishOptions,
+    QueueTiAuth,
     connect,
 )
 
@@ -32,6 +35,8 @@ ADMIN_URL = "http://localhost:8080"
 TOPIC = "orders"
 DLQ_TOPIC = "orders.dlq"
 CONSUMER_GROUP = "fulfillment"
+USERNAME = os.environ.get("QUEUETI_USERNAME", "admin")
+PASSWORD = os.environ.get("QUEUETI_PASSWORD", "secret")
 
 
 @dataclasses.dataclass
@@ -51,8 +56,8 @@ ORDERS = [
 ]
 
 
-async def register_consumer_group() -> None:
-    async with AsyncAdminClient(ADMIN_URL) as admin:
+async def register_consumer_group(auth: QueueTiAuth) -> None:
+    async with AsyncAdminClient(ADMIN_URL, AdminOptions(token=auth.token)) as admin:
         try:
             await admin.register_consumer_group(TOPIC, CONSUMER_GROUP)
             log.info("consumer group %r registered", CONSUMER_GROUP)
@@ -63,8 +68,12 @@ async def register_consumer_group() -> None:
                 raise
 
 
-async def produce(stop: asyncio.Event) -> None:
-    client = await connect(GRPC_ADDR, ConnectOptions(insecure=True))
+async def produce(auth: QueueTiAuth, stop: asyncio.Event) -> None:
+    client = await connect(GRPC_ADDR, ConnectOptions(
+        insecure=True,
+        token=auth.token,
+        token_refresher=auth.async_refresh,
+    ))
     producer = client.producer()
 
     for order in ORDERS:
@@ -82,8 +91,12 @@ async def produce(stop: asyncio.Event) -> None:
     await client.close()
 
 
-async def consume(stop: asyncio.Event) -> None:
-    client = await connect(GRPC_ADDR, ConnectOptions(insecure=True))
+async def consume(auth: QueueTiAuth, stop: asyncio.Event) -> None:
+    client = await connect(GRPC_ADDR, ConnectOptions(
+        insecure=True,
+        token=auth.token,
+        token_refresher=auth.async_refresh,
+    ))
     consumer = client.consumer(
         TOPIC,
         ConsumerOptions(consumer_group=CONSUMER_GROUP, concurrency=3),
@@ -112,8 +125,12 @@ async def consume(stop: asyncio.Event) -> None:
     await client.close()
 
 
-async def drain_dlq() -> None:
-    client = await connect(GRPC_ADDR, ConnectOptions(insecure=True))
+async def drain_dlq(auth: QueueTiAuth) -> None:
+    client = await connect(GRPC_ADDR, ConnectOptions(
+        insecure=True,
+        token=auth.token,
+        token_refresher=auth.async_refresh,
+    ))
     consumer = client.consumer(
         DLQ_TOPIC,
         ConsumerOptions(consumer_group=CONSUMER_GROUP),
@@ -130,6 +147,8 @@ async def drain_dlq() -> None:
 
 
 async def main() -> None:
+    auth = QueueTiAuth.login(ADMIN_URL, USERNAME, PASSWORD)
+
     stop = asyncio.Event()
 
     def _shutdown() -> None:
@@ -140,12 +159,12 @@ async def main() -> None:
     for sig in (signal.SIGINT, signal.SIGTERM):
         loop.add_signal_handler(sig, _shutdown)
 
-    await register_consumer_group()
+    await register_consumer_group(auth)
 
     async with asyncio.TaskGroup() as tg:
-        tg.create_task(produce(stop))
-        tg.create_task(drain_dlq())
-        tg.create_task(consume(stop))
+        tg.create_task(produce(auth, stop))
+        tg.create_task(drain_dlq(auth))
+        tg.create_task(consume(auth, stop))
 
 
 if __name__ == "__main__":

--- a/clients/python/queueti/__init__.py
+++ b/clients/python/queueti/__init__.py
@@ -1,5 +1,6 @@
 """queue-ti Python client library."""
 
+from queueti._auth import QueueTiAuth
 from queueti._admin import AdminOptions, AsyncAdminClient, TopicConfig, TopicSchema, TopicStat
 from queueti._client import AsyncClient, connect
 from queueti._consumer import AsyncConsumer, BatchHandler, MessageHandler
@@ -10,6 +11,8 @@ from queueti._producer import AsyncProducer
 from queueti._sync import Client, Consumer, Producer, connect_sync
 
 __all__ = [
+    # Auth
+    "QueueTiAuth",
     # Async API
     "connect",
     "AsyncClient",

--- a/clients/python/queueti/_auth.py
+++ b/clients/python/queueti/_auth.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import json
+from typing import Callable, Awaitable
+
+import httpx
+
+
+class QueueTiAuth:
+    """Handles authentication against the queue-ti admin HTTP API.
+
+    Use the :meth:`login` classmethod to construct an instance.  When the
+    server does not require authentication, ``token`` is ``None`` and
+    :meth:`refresh` is a no-op.
+    """
+
+    def __init__(self, token: str | None, _base: str, _username: str, _password: str) -> None:
+        self.token: str | None = token
+        self._base = _base
+        self._username = _username
+        self._password = _password
+
+    @classmethod
+    def login(cls, admin_addr: str, username: str, password: str) -> "QueueTiAuth":
+        """Check auth status and perform a synchronous login if required.
+
+        :param admin_addr: Base URL of the admin API, e.g. ``"http://localhost:8080"``.
+                           A trailing slash is stripped automatically.
+        :param username: Username for authentication.
+        :param password: Password for authentication.
+        :returns: A :class:`QueueTiAuth` instance.
+        :raises httpx.HTTPError: On network or HTTP errors.
+        """
+        base = admin_addr.rstrip("/")
+        with httpx.Client() as client:
+            status_resp = client.get(f"{base}/api/auth/status")
+            status_resp.raise_for_status()
+            auth_required = status_resp.json().get("auth_required", False)
+
+            if not auth_required:
+                return cls(None, base, username, password)
+
+            token = cls._do_login(client, base, username, password)
+            return cls(token, base, username, password)
+
+    @staticmethod
+    def _do_login(client: httpx.Client, base: str, username: str, password: str) -> str:
+        resp = client.post(
+            f"{base}/api/auth/login",
+            content=json.dumps({"username": username, "password": password}),
+            headers={"Content-Type": "application/json"},
+        )
+        resp.raise_for_status()
+        token = resp.json().get("token", "")
+        if not token:
+            raise ValueError("queue-ti auth: server returned empty token")
+        return str(token)
+
+    def refresh(self) -> str:
+        """Re-authenticate and return the new token.
+
+        Compatible with the sync ``token_refresher`` hook.  When auth is
+        disabled (``token`` is ``None``), this is a no-op and returns ``""``.
+        """
+        if self.token is None:
+            return ""
+        with httpx.Client() as client:
+            self.token = self._do_login(client, self._base, self._username, self._password)
+        return self.token
+
+    async def async_refresh(self) -> str:
+        """Re-authenticate asynchronously and return the new token.
+
+        Compatible with the async ``token_refresher`` hook.  When auth is
+        disabled (``token`` is ``None``), this is a no-op and returns ``""``.
+        """
+        if self.token is None:
+            return ""
+        async with httpx.AsyncClient() as client:
+            resp = await client.post(
+                f"{self._base}/api/auth/login",
+                content=json.dumps({"username": self._username, "password": self._password}),
+                headers={"Content-Type": "application/json"},
+            )
+            resp.raise_for_status()
+            token = resp.json().get("token", "")
+            if not token:
+                raise ValueError("queue-ti auth: server returned empty token")
+            self.token = str(token)
+        return self.token

--- a/clients/python/queueti/_auth.py
+++ b/clients/python/queueti/_auth.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-from typing import Callable, Awaitable
 
 import httpx
 
@@ -56,6 +55,19 @@ class QueueTiAuth:
             raise ValueError("queue-ti auth: server returned empty token")
         return str(token)
 
+    @staticmethod
+    async def _async_do_login(client: httpx.AsyncClient, base: str, username: str, password: str) -> str:
+        resp = await client.post(
+            f"{base}/api/auth/login",
+            content=json.dumps({"username": username, "password": password}),
+            headers={"Content-Type": "application/json"},
+        )
+        resp.raise_for_status()
+        token = resp.json().get("token", "")
+        if not token:
+            raise ValueError("queue-ti auth: server returned empty token")
+        return str(token)
+
     def refresh(self) -> str:
         """Re-authenticate and return the new token.
 
@@ -77,14 +89,5 @@ class QueueTiAuth:
         if self.token is None:
             return ""
         async with httpx.AsyncClient() as client:
-            resp = await client.post(
-                f"{self._base}/api/auth/login",
-                content=json.dumps({"username": self._username, "password": self._password}),
-                headers={"Content-Type": "application/json"},
-            )
-            resp.raise_for_status()
-            token = resp.json().get("token", "")
-            if not token:
-                raise ValueError("queue-ti auth: server returned empty token")
-            self.token = str(token)
+            self.token = await self._async_do_login(client, self._base, self._username, self._password)
         return self.token

--- a/clients/python/tests/test_auth.py
+++ b/clients/python/tests/test_auth.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from queueti._auth import QueueTiAuth
+
+
+def _make_response(status_code: int = 200, body: object = None) -> MagicMock:
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.is_success = 200 <= status_code < 300
+    resp.json.return_value = body or {}
+    resp.raise_for_status = MagicMock()
+    if not resp.is_success:
+        resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            message=f"HTTP {status_code}",
+            request=MagicMock(),
+            response=resp,
+        )
+    return resp
+
+
+class TestQueueTiAuthLogin:
+    def test_no_auth_required_returns_none_token(self) -> None:
+        status_resp = _make_response(body={"auth_required": False})
+        with patch("httpx.Client") as mock_client_cls:
+            mock_client = mock_client_cls.return_value.__enter__.return_value
+            mock_client.get.return_value = status_resp
+
+            auth = QueueTiAuth.login("http://localhost:8080", "user", "pass")
+
+        assert auth.token is None
+        mock_client.post.assert_not_called()
+
+    def test_no_auth_required_strips_trailing_slash(self) -> None:
+        status_resp = _make_response(body={"auth_required": False})
+        with patch("httpx.Client") as mock_client_cls:
+            mock_client = mock_client_cls.return_value.__enter__.return_value
+            mock_client.get.return_value = status_resp
+
+            QueueTiAuth.login("http://localhost:8080/", "u", "p")
+
+        mock_client.get.assert_called_once_with("http://localhost:8080/api/auth/status")
+
+    def test_auth_required_returns_token(self) -> None:
+        status_resp = _make_response(body={"auth_required": True})
+        login_resp = _make_response(body={"token": "jwt-abc"})
+        with patch("httpx.Client") as mock_client_cls:
+            mock_client = mock_client_cls.return_value.__enter__.return_value
+            mock_client.get.return_value = status_resp
+            mock_client.post.return_value = login_resp
+
+            auth = QueueTiAuth.login("http://localhost:8080", "admin", "secret")
+
+        assert auth.token == "jwt-abc"
+
+    def test_auth_required_sends_json_encoded_credentials(self) -> None:
+        status_resp = _make_response(body={"auth_required": True})
+        login_resp = _make_response(body={"token": "tok"})
+        with patch("httpx.Client") as mock_client_cls:
+            mock_client = mock_client_cls.return_value.__enter__.return_value
+            mock_client.get.return_value = status_resp
+            mock_client.post.return_value = login_resp
+
+            QueueTiAuth.login("http://localhost:8080", 'user"name', 'p\\a"ss')
+
+        _, kwargs = mock_client.post.call_args
+        body = json.loads(kwargs["content"])
+        assert body["username"] == 'user"name'
+        assert body["password"] == 'p\\a"ss'
+
+    def test_login_failure_raises(self) -> None:
+        status_resp = _make_response(body={"auth_required": True})
+        login_resp = _make_response(status_code=401, body={"error": "invalid credentials"})
+        with patch("httpx.Client") as mock_client_cls:
+            mock_client = mock_client_cls.return_value.__enter__.return_value
+            mock_client.get.return_value = status_resp
+            mock_client.post.return_value = login_resp
+
+            with pytest.raises(httpx.HTTPStatusError):
+                QueueTiAuth.login("http://localhost:8080", "bad", "creds")
+
+    def test_empty_token_in_response_raises(self) -> None:
+        status_resp = _make_response(body={"auth_required": True})
+        login_resp = _make_response(body={"token": ""})
+        with patch("httpx.Client") as mock_client_cls:
+            mock_client = mock_client_cls.return_value.__enter__.return_value
+            mock_client.get.return_value = status_resp
+            mock_client.post.return_value = login_resp
+
+            with pytest.raises(ValueError, match="empty token"):
+                QueueTiAuth.login("http://localhost:8080", "u", "p")
+
+
+class TestQueueTiAuthRefresh:
+    def test_refresh_is_noop_when_auth_disabled(self) -> None:
+        status_resp = _make_response(body={"auth_required": False})
+        with patch("httpx.Client") as mock_client_cls:
+            mock_client = mock_client_cls.return_value.__enter__.return_value
+            mock_client.get.return_value = status_resp
+            auth = QueueTiAuth.login("http://localhost:8080", "u", "p")
+
+        result = auth.refresh()
+        assert result == ""
+        assert auth.token is None
+
+    def test_refresh_reauthenticates_and_updates_token(self) -> None:
+        status_resp = _make_response(body={"auth_required": True})
+        login_resp_1 = _make_response(body={"token": "initial"})
+        login_resp_2 = _make_response(body={"token": "refreshed"})
+        with patch("httpx.Client") as mock_client_cls:
+            mock_client = mock_client_cls.return_value.__enter__.return_value
+            mock_client.get.return_value = status_resp
+            mock_client.post.return_value = login_resp_1
+            auth = QueueTiAuth.login("http://localhost:8080", "admin", "secret")
+        assert auth.token == "initial"
+
+        refresh_resp = _make_response(body={"token": "refreshed"})
+        with patch("httpx.Client") as mock_client_cls:
+            mock_client = mock_client_cls.return_value.__enter__.return_value
+            mock_client.post.return_value = refresh_resp
+            result = auth.refresh()
+
+        assert result == "refreshed"
+        assert auth.token == "refreshed"
+        _ = login_resp_2  # silence unused warning
+
+
+@pytest.mark.asyncio
+class TestQueueTiAuthAsyncRefresh:
+    async def test_async_refresh_is_noop_when_auth_disabled(self) -> None:
+        status_resp = _make_response(body={"auth_required": False})
+        with patch("httpx.Client") as mock_client_cls:
+            mock_client = mock_client_cls.return_value.__enter__.return_value
+            mock_client.get.return_value = status_resp
+            auth = QueueTiAuth.login("http://localhost:8080", "u", "p")
+
+        result = await auth.async_refresh()
+        assert result == ""
+
+    async def test_async_refresh_reauthenticates(self) -> None:
+        from unittest.mock import AsyncMock
+
+        status_resp = _make_response(body={"auth_required": True})
+        login_resp = _make_response(body={"token": "initial"})
+        with patch("httpx.Client") as mock_client_cls:
+            mock_client = mock_client_cls.return_value.__enter__.return_value
+            mock_client.get.return_value = status_resp
+            mock_client.post.return_value = login_resp
+            auth = QueueTiAuth.login("http://localhost:8080", "admin", "secret")
+
+        refresh_resp = MagicMock(spec=httpx.Response)
+        refresh_resp.json.return_value = {"token": "async-refreshed"}
+        refresh_resp.raise_for_status = MagicMock()
+
+        with patch("httpx.AsyncClient") as mock_async_cls:
+            mock_async_client = mock_async_cls.return_value.__aenter__.return_value
+            mock_async_client.post = AsyncMock(return_value=refresh_resp)
+            result = await auth.async_refresh()
+
+        assert result == "async-refreshed"
+        assert auth.token == "async-refreshed"

--- a/clients/python/tests/test_auth.py
+++ b/clients/python/tests/test_auth.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
@@ -110,12 +110,11 @@ class TestQueueTiAuthRefresh:
 
     def test_refresh_reauthenticates_and_updates_token(self) -> None:
         status_resp = _make_response(body={"auth_required": True})
-        login_resp_1 = _make_response(body={"token": "initial"})
-        login_resp_2 = _make_response(body={"token": "refreshed"})
+        login_resp = _make_response(body={"token": "initial"})
         with patch("httpx.Client") as mock_client_cls:
             mock_client = mock_client_cls.return_value.__enter__.return_value
             mock_client.get.return_value = status_resp
-            mock_client.post.return_value = login_resp_1
+            mock_client.post.return_value = login_resp
             auth = QueueTiAuth.login("http://localhost:8080", "admin", "secret")
         assert auth.token == "initial"
 
@@ -127,7 +126,6 @@ class TestQueueTiAuthRefresh:
 
         assert result == "refreshed"
         assert auth.token == "refreshed"
-        _ = login_resp_2  # silence unused warning
 
 
 @pytest.mark.asyncio
@@ -143,8 +141,6 @@ class TestQueueTiAuthAsyncRefresh:
         assert result == ""
 
     async def test_async_refresh_reauthenticates(self) -> None:
-        from unittest.mock import AsyncMock
-
         status_resp = _make_response(body={"auth_required": True})
         login_resp = _make_response(body={"token": "initial"})
         with patch("httpx.Client") as mock_client_cls:

--- a/docs/clients/go.md
+++ b/docs/clients/go.md
@@ -209,7 +209,46 @@ if err != nil {
 
 ## Authentication
 
-### With JWT Tokens
+### Using QueueTiAuth (recommended)
+
+The `NewAuth` helper automatically checks if authentication is required and handles login and token refresh:
+
+```go
+auth, err := queueti.NewAuth("http://localhost:8080", "admin", "secret")
+if err != nil {
+    log.Fatal(err)
+}
+
+// Build dial options conditionally on whether auth is enabled
+opts := []queueti.DialOption{queueti.WithInsecure()}
+
+// If auth is required, add token and refresh
+if auth.Token() != "" {
+    opts = append(opts,
+        queueti.WithBearerToken(auth.Token()),
+        queueti.WithTokenRefresher(auth.Refresh),
+    )
+}
+
+client, err := queueti.Dial("localhost:50051", opts...)
+if err != nil {
+    log.Fatal(err)
+}
+defer client.Close()
+
+// For the admin client
+adminClient := queueti.NewAdminClient("http://localhost:8080",
+    queueti.WithAdminToken(auth.Token()),
+)
+```
+
+The `NewAuth` helper:
+1. Calls `GET /api/auth/status` to check if authentication is required
+2. If auth is disabled, returns a no-op instance with an empty token
+3. If auth is enabled, calls `POST /api/auth/login` with the provided credentials
+4. Exposes `Token()` for the current JWT and `Refresh(ctx)` which satisfies the `TokenRefresher` interface for automatic token refresh
+
+### With JWT Tokens (manual)
 
 ```go
 // Login to get initial token

--- a/docs/clients/go.md
+++ b/docs/clients/go.md
@@ -349,7 +349,8 @@ For complete examples and method signatures, see [clients/go-client/admin.go](ht
 
 A self-contained end-to-end example demonstrating the full producer → consumer → ack lifecycle:
 
-- Client creation and consumer group registration via the admin REST API
+- Authentication via `NewAuth` — checks server auth status, logs in, and wires `TokenRefresher` automatically
+- Consumer group registration via `AdminClient`
 - Publishing messages with metadata and a deduplication key
 - Streaming consumption with `concurrency=3`, ack on success, nack on failure (poison pill)
 - DLQ drain — batch-polls `orders.dlq` and acks dead-lettered messages
@@ -359,6 +360,8 @@ A self-contained end-to-end example demonstrating the full producer → consumer
 
 ```bash
 # Requires: docker-compose up (from repo root)
+# Credentials default to admin/secret; override with env vars:
+# QUEUETI_USERNAME=admin QUEUETI_PASSWORD=secret go run .
 go run .
 ```
 

--- a/docs/clients/go.md
+++ b/docs/clients/go.md
@@ -219,10 +219,7 @@ if err != nil {
     log.Fatal(err)
 }
 
-// Build dial options conditionally on whether auth is enabled
 opts := []queueti.DialOption{queueti.WithInsecure()}
-
-// If auth is required, add token and refresh
 if auth.Token() != "" {
     opts = append(opts,
         queueti.WithBearerToken(auth.Token()),
@@ -236,7 +233,6 @@ if err != nil {
 }
 defer client.Close()
 
-// For the admin client
 adminClient := queueti.NewAdminClient("http://localhost:8080",
     queueti.WithAdminToken(auth.Token()),
 )

--- a/docs/clients/nodejs.md
+++ b/docs/clients/nodejs.md
@@ -201,23 +201,47 @@ try {
 
 ## Authentication
 
-### With JWT Tokens
+### Using QueueTiAuth (recommended)
+
+The `QueueTiAuth` helper automatically checks if authentication is required and handles login and token refresh:
+
+```typescript
+import { connect, AdminClient, QueueTiAuth } from '@queue-ti/client'
+
+const auth = await QueueTiAuth.login('http://localhost:8080', 'admin', 'secret')
+
+const client = await connect('localhost:50051', {
+  insecure: true,
+  token: auth.token ?? undefined,
+  tokenRefresher: auth.refresh,
+})
+
+const admin = new AdminClient('http://localhost:8080', {
+  token: auth.token ?? undefined,
+})
+```
+
+The `QueueTiAuth` helper:
+1. Calls `GET /api/auth/status` to check if authentication is required
+2. If auth is disabled, returns a no-op instance with a null token
+3. If auth is enabled, calls `POST /api/auth/login` with the provided credentials
+4. Exposes `.token` (string or null) for the current JWT and `.refresh` (arrow function) which satisfies the `ConnectOptions.tokenRefresher` interface for automatic token refresh
+
+### With JWT Tokens (manual)
 
 ```typescript
 import { connect } from '@queue-ti/client'
 
 const client = await connect('localhost:50051', {
   insecure: true,
-  auth: {
-    token: initialToken,
-    refreshToken: async () => {
-      const response = await fetch('http://localhost:8080/api/auth/refresh', {
-        method: 'POST',
-        headers: { 'Authorization': `Bearer ${currentToken}` },
-      })
-      const data = await response.json()
-      return data.token
-    },
+  token: initialToken,
+  tokenRefresher: async () => {
+    const response = await fetch('http://localhost:8080/api/auth/refresh', {
+      method: 'POST',
+      headers: { 'Authorization': `Bearer ${currentToken}` },
+    })
+    const data = await response.json()
+    return data.token
   },
 })
 ```

--- a/docs/clients/nodejs.md
+++ b/docs/clients/nodejs.md
@@ -236,9 +236,10 @@ const client = await connect('localhost:50051', {
   insecure: true,
   token: initialToken,
   tokenRefresher: async () => {
-    const response = await fetch('http://localhost:8080/api/auth/refresh', {
+    const response = await fetch('http://localhost:8080/api/auth/login', {
       method: 'POST',
-      headers: { 'Authorization': `Bearer ${currentToken}` },
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: 'admin', password: 'secret' }),
     })
     const data = await response.json()
     return data.token

--- a/docs/clients/nodejs.md
+++ b/docs/clients/nodejs.md
@@ -332,7 +332,8 @@ For complete examples and method signatures, see [clients/node/src/admin.ts](htt
 
 A self-contained end-to-end example demonstrating the full producer → consumer → ack lifecycle:
 
-- Client creation and consumer group registration via the admin REST API
+- Authentication via `QueueTiAuth.login` — checks server auth status, logs in, and wires `tokenRefresher` automatically
+- Consumer group registration via `AdminClient`
 - Publishing messages with metadata and a deduplication key
 - Streaming consumption with `concurrency: 3`, ack on success, nack on failure (poison pill)
 - DLQ drain — batch-polls `orders.dlq` and acks dead-lettered messages
@@ -342,8 +343,10 @@ A self-contained end-to-end example demonstrating the full producer → consumer
 
 ```bash
 # From clients/node/ — requires: docker-compose up (from repo root)
+# Credentials default to admin/secret; override with env vars:
+# QUEUETI_USERNAME=admin QUEUETI_PASSWORD=secret npx ts-node --transpile-only examples/order-pipeline/index.ts
 npm install
-npx ts-node --esm examples/order-pipeline/index.ts
+npx ts-node --transpile-only examples/order-pipeline/index.ts
 ```
 
 ## Full Client Documentation

--- a/docs/clients/python.md
+++ b/docs/clients/python.md
@@ -282,7 +282,7 @@ async def main():
 asyncio.run(main())
 ```
 
-For the synchronous client, use `connect_sync` and `refresh()` (the sync variant of `async_refresh()`):
+For the synchronous client, use `connect_sync` with `async_refresh` — the sync wrapper runs an internal event loop and requires an async refresher:
 
 ```python
 import queueti

--- a/docs/clients/python.md
+++ b/docs/clients/python.md
@@ -250,7 +250,43 @@ except Exception as err:
 
 ## Authentication
 
-### With JWT Tokens
+### Using QueueTiAuth (recommended)
+
+The `QueueTiAuth` helper automatically checks if authentication is required and handles login and token refresh:
+
+```python
+import asyncio
+import queueti
+
+auth = queueti.QueueTiAuth.login("http://localhost:8080", "admin", "secret")
+
+async def main():
+    opts = queueti.ConnectOptions(
+        token=auth.token,
+        token_refresher=auth.async_refresh,
+    )
+    async with await queueti.connect("localhost:50051", opts) as client:
+        producer = client.producer()
+        msg_id = await producer.publish("orders", b"...")
+        print(f"Published: {msg_id}")
+
+    admin = queueti.AsyncAdminClient(
+        "http://localhost:8080",
+        queueti.AdminOptions(token=auth.token),
+    )
+    configs = await admin.list_topic_configs()
+    await admin.close()
+
+asyncio.run(main())
+```
+
+The `QueueTiAuth` helper:
+1. Calls `GET /api/auth/status` to check if authentication is required
+2. If auth is disabled, returns a no-op instance with a null token
+3. If auth is enabled, calls `POST /api/auth/login` with the provided credentials
+4. Exposes `.token` (str or None) for the current JWT and `.async_refresh()` (async callable) which satisfies the `ConnectOptions.token_refresher` interface for automatic token refresh
+
+### With JWT Tokens (manual)
 
 ```python
 import asyncio

--- a/docs/clients/python.md
+++ b/docs/clients/python.md
@@ -265,53 +265,116 @@ async def main():
         token=auth.token,
         token_refresher=auth.async_refresh,
     )
-    async with await queueti.connect("localhost:50051", opts) as client:
+    client = await queueti.connect("localhost:50051", opts)
+    try:
         producer = client.producer()
         msg_id = await producer.publish("orders", b"...")
         print(f"Published: {msg_id}")
+    finally:
+        await client.close()
 
-    admin = queueti.AsyncAdminClient(
+    async with queueti.AsyncAdminClient(
         "http://localhost:8080",
         queueti.AdminOptions(token=auth.token),
-    )
-    configs = await admin.list_topic_configs()
-    await admin.close()
+    ) as admin:
+        configs = await admin.list_topic_configs()
 
 asyncio.run(main())
+```
+
+For the synchronous client, use `connect_sync` and `refresh()` (the sync variant of `async_refresh()`):
+
+```python
+import queueti
+
+auth = queueti.QueueTiAuth.login("http://localhost:8080", "admin", "secret")
+
+client = queueti.connect_sync("localhost:50051", queueti.ConnectOptions(
+    token=auth.token,
+    token_refresher=auth.async_refresh,
+))
+try:
+    producer = client.producer()
+    msg_id = producer.publish("orders", b"...")
+    print(f"Published: {msg_id}")
+finally:
+    client.close()
 ```
 
 The `QueueTiAuth` helper:
 1. Calls `GET /api/auth/status` to check if authentication is required
 2. If auth is disabled, returns a no-op instance with a null token
 3. If auth is enabled, calls `POST /api/auth/login` with the provided credentials
-4. Exposes `.token` (str or None) for the current JWT and `.async_refresh()` (async callable) which satisfies the `ConnectOptions.token_refresher` interface for automatic token refresh
+4. Exposes `.token` (str or None) for the current JWT, `.async_refresh()` for async clients, and `.refresh()` for sync clients
 
-### With JWT Tokens (manual)
+### Option 1 — Obtaining a token manually
+
+```bash
+TOKEN=$(curl -s -X POST http://localhost:8080/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"username":"admin","password":"secret"}' \
+  | jq -r '.token')
+```
+
+### Option 2 — Automatic refresh with custom fetcher
 
 ```python
 import asyncio
 from queueti import connect, ConnectOptions
 
-async def refresh_token(current_token):
-    # Your token refresh logic
-    response = await http_client.post(
-        "http://localhost:8080/api/auth/refresh",
-        headers={"Authorization": f"Bearer {current_token}"},
-    )
-    data = await response.json()
-    return data["token"]
+async def refresh_token() -> str:
+    import httpx
+    async with httpx.AsyncClient() as http:
+        resp = await http.post(
+            "http://localhost:8080/api/auth/login",
+            json={"username": "admin", "password": "secret"},
+        )
+        return resp.json()["token"]
 
 async def main():
     client = await connect(
         "localhost:50051",
-        options=ConnectOptions(
-            insecure=True,
-            auth_token=initial_token,
+        ConnectOptions(
+            token="initial-token",
             token_refresher=refresh_token,
         ),
     )
+    try:
+        ...
+    finally:
+        await client.close()
 
 asyncio.run(main())
+```
+
+### Option 3 — Manual update
+
+Call `client.set_token()` to swap the token on a live connection. The new token takes effect on the very next RPC call; no reconnection is needed.
+
+```python
+client = await connect(
+    "localhost:50051",
+    ConnectOptions(token="initial-token"),
+)
+
+# Later, when you have a fresh token:
+client.set_token("new-token")
+```
+
+This is useful when token lifecycle is managed externally (e.g. a shared token store, a sidecar, or an existing refresh loop in your application).
+
+### Option 4 — Static token (short-lived processes)
+
+For scripts or batch jobs that complete within the 15-minute token window, a static token is sufficient:
+
+```python
+import os
+from queueti import connect, ConnectOptions
+
+client = await connect(
+    "localhost:50051",
+    ConnectOptions(token=os.getenv("QUEUETI_TOKEN")),
+)
 ```
 
 ## Consumer Groups

--- a/docs/clients/python.md
+++ b/docs/clients/python.md
@@ -478,7 +478,8 @@ For complete examples and method signatures, see [clients/python/queueti/_admin.
 
 A self-contained end-to-end example demonstrating the full producer → consumer → ack lifecycle:
 
-- Client creation and consumer group registration via the admin REST API
+- Authentication via `QueueTiAuth.login` — checks server auth status, logs in, and wires `async_refresh` automatically
+- Consumer group registration via `AsyncAdminClient`
 - Publishing messages with metadata
 - Streaming consumption with `concurrency=3`, ack on success, nack on failure (poison pill)
 - DLQ drain — batch-polls `orders.dlq` and acks dead-lettered messages
@@ -488,6 +489,8 @@ A self-contained end-to-end example demonstrating the full producer → consumer
 
 ```bash
 # From clients/python/ — requires: docker-compose up (from repo root)
+# Credentials default to admin/secret; override with env vars:
+# QUEUETI_USERNAME=admin QUEUETI_PASSWORD=secret python examples/order_pipeline/main.py
 pip install -e ".[dev]"
 python examples/order_pipeline/main.py
 ```


### PR DESCRIPTION
Closes #58

## Summary

- **Go** (`clients/go-client/auth.go`): `NewAuth(adminAddr, username, password) (*Auth, error)` — checks `/api/auth/status`, calls `/api/auth/login` when required, returns an `*Auth` whose `Token() string` and `Refresh(ctx) (string, error)` (implements `TokenRefresher`) can be wired directly into `Dial` options.
- **Node.js** (`clients/node/src/auth.ts`): `QueueTiAuth.login(adminAddr, username, password)` static async factory — exposes `.token: string | null` and `.refresh: TokenRefresher` for wiring into `ConnectOptions`.
- **Python** (`clients/python/queueti/_auth.py`): `QueueTiAuth.login(admin_addr, username, password)` sync classmethod — exposes `.token: str | None`, `.refresh()` (sync), and `.async_refresh()` (async) for both sync and async client paths.

All three mirror the Java reference implementation: `/api/auth/status` is always checked first; when auth is not required a valid no-op instance is returned; credentials are JSON-encoded (not interpolated); the HTTP client is reused across login and refresh; trailing slashes are stripped.

## Test coverage

- Go: 8 new Ginkgo specs (`auth_test.go`) — 44/44 total pass
- Node.js: 9 new Vitest specs (`auth.spec.ts`) — 63/63 total pass
- Python: 10 new pytest tests (`test_auth.py`) — 77/77 total pass