### PR TITLE
fix(queue): honour per-topic MaxRetries for DLQ promotion

### DIFF
--- a/backend/internal/queue/consumer_group_test.go
+++ b/backend/internal/queue/consumer_group_test.go
@@ -551,5 +551,97 @@ var _ = Describe("Consumer Groups", func() {
 				Expect(err).To(MatchError(ContainSubstring(queue.ErrNotProcessing.Error())))
 			})
 		})
+
+		Context("when a per-topic MaxRetries is lower than the global dlqThreshold", func() {
+			const perTopicTopic = "cg-per-topic-low"
+			var msgID string
+
+			BeforeEach(func() {
+				// Global dlqThreshold = 5 — without the fix one nack would leave
+				// the delivery as 'pending'. Per-topic MaxRetries = 1 should take
+				// precedence and mark the delivery 'failed' immediately.
+				svc = queue.NewService(pool, 30*time.Second, 3, 0, 5, false, queue.NoopRecorder{})
+
+				perTopicRetries := 1
+				err := svc.UpsertTopicConfig(ctx, queue.TopicConfig{
+					Topic:      perTopicTopic,
+					MaxRetries: &perTopicRetries,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(svc.RegisterConsumerGroup(ctx, perTopicTopic, "groupA")).To(Succeed())
+
+				msgID, err = svc.Enqueue(ctx, perTopicTopic, []byte("work"), nil, nil)
+				Expect(err).NotTo(HaveOccurred())
+
+				_, err = svc.DequeueForGroup(ctx, perTopicTopic, "groupA", 30*time.Second)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should mark the delivery failed after the first nack", func() {
+				Expect(svc.NackForGroup(ctx, msgID, "groupA", "threshold hit")).To(Succeed())
+
+				var status string
+				Expect(pool.QueryRow(ctx,
+					`SELECT status FROM message_deliveries WHERE message_id = $1 AND consumer_group = 'groupA'`, msgID,
+				).Scan(&status)).To(Succeed())
+				Expect(status).To(Equal("failed"))
+			})
+		})
+
+		Context("when a per-topic MaxRetries is higher than the global dlqThreshold", func() {
+			const perTopicTopic = "cg-per-topic-high"
+			var msgID string
+
+			BeforeEach(func() {
+				// Global dlqThreshold = 1 — without the fix one nack would mark
+				// the delivery 'failed'. Per-topic MaxRetries = 3 should override
+				// and keep the delivery 'pending' so it can be retried.
+				svc = queue.NewService(pool, 30*time.Second, 3, 0, 1, false, queue.NoopRecorder{})
+
+				perTopicRetries := 3
+				err := svc.UpsertTopicConfig(ctx, queue.TopicConfig{
+					Topic:      perTopicTopic,
+					MaxRetries: &perTopicRetries,
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(svc.RegisterConsumerGroup(ctx, perTopicTopic, "groupA")).To(Succeed())
+
+				msgID, err = svc.Enqueue(ctx, perTopicTopic, []byte("work"), nil, nil)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should keep the delivery pending after the first nack", func() {
+				_, err := svc.DequeueForGroup(ctx, perTopicTopic, "groupA", 30*time.Second)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(svc.NackForGroup(ctx, msgID, "groupA", "transient")).To(Succeed())
+
+				var status string
+				Expect(pool.QueryRow(ctx,
+					`SELECT status FROM message_deliveries WHERE message_id = $1 AND consumer_group = 'groupA'`, msgID,
+				).Scan(&status)).To(Succeed())
+				Expect(status).To(Equal("pending"))
+			})
+
+			It("should mark the delivery failed on the third nack", func() {
+				for i := range 3 {
+					_, err := svc.DequeueForGroup(ctx, perTopicTopic, "groupA", 30*time.Second)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(svc.NackForGroup(ctx, msgID, "groupA", "transient")).To(Succeed())
+
+					var status string
+					Expect(pool.QueryRow(ctx,
+						`SELECT status FROM message_deliveries WHERE message_id = $1 AND consumer_group = 'groupA'`, msgID,
+					).Scan(&status)).To(Succeed())
+
+					if i < 2 {
+						Expect(status).To(Equal("pending"), "expected pending after nack %d", i+1)
+					} else {
+						Expect(status).To(Equal("failed"), "expected failed after nack %d", i+1)
+					}
+				}
+			})
+		})
 	})
 })

--- a/backend/internal/queue/lifecycle.go
+++ b/backend/internal/queue/lifecycle.go
@@ -10,6 +10,16 @@ import (
 	"github.com/jackc/pgx/v5"
 )
 
+// effectiveDLQThreshold returns the DLQ threshold to apply for a given topic.
+// Per-topic MaxRetries takes precedence over the global dlqThreshold when set.
+func (s *Service) effectiveDLQThreshold(ctx context.Context, topic string) int {
+	cfg, err := s.GetTopicConfig(ctx, topic)
+	if err == nil && cfg != nil && cfg.MaxRetries != nil {
+		return *cfg.MaxRetries
+	}
+	return s.dlqThreshold
+}
+
 // archiveToLog inserts a message into message_log when the topic is configured
 // as replayable. It is a no-op (nil error) when the topic is not replayable.
 func (s *Service) archiveToLog(ctx context.Context, tx pgx.Tx, id, topic string, key *string, payload, metaJSON []byte, retryCount, maxRetries int, lastError, originalTopic *string, createdAt time.Time) error {
@@ -115,7 +125,8 @@ func (s *Service) Nack(ctx context.Context, id string, processingError string) e
 	nextRetryCount := retryCount + 1
 
 	// Promote to DLQ when the threshold is configured and reached.
-	if s.dlqThreshold > 0 && nextRetryCount >= s.dlqThreshold {
+	dlqThreshold := s.effectiveDLQThreshold(ctx, topic)
+	if dlqThreshold > 0 && nextRetryCount >= dlqThreshold {
 		dlqTopic := topic + ".dlq"
 		_, err = tx.Exec(ctx, `
 			UPDATE messages
@@ -294,7 +305,8 @@ func (s *Service) NackForGroup(ctx context.Context, id, group, processingError s
 	// When the DLQ threshold is configured and reached, mark the delivery
 	// failed without touching the parent message — full per-group DLQ
 	// promotion is deferred to a future phase.
-	if s.dlqThreshold > 0 && nextRetryCount >= s.dlqThreshold {
+	dlqThreshold := s.effectiveDLQThreshold(ctx, topic)
+	if dlqThreshold > 0 && nextRetryCount >= dlqThreshold {
 		_, err = tx.Exec(ctx, `
 			UPDATE message_deliveries
 			SET    status      = 'failed',
@@ -390,7 +402,7 @@ func (s *Service) Requeue(ctx context.Context, id string) error {
 		    visibility_timeout = NULL,
 		    updated_at     = now()
 		WHERE id = $1
-	`, id, *originalTopic, s.dlqThreshold)
+	`, id, *originalTopic, s.effectiveDLQThreshold(ctx, *originalTopic))
 	if err != nil {
 		return fmt.Errorf("requeue update: %w", err)
 	}

--- a/backend/internal/queue/service_test.go
+++ b/backend/internal/queue/service_test.go
@@ -592,6 +592,103 @@ var _ = Describe("Queue Service", func() {
 					Expect(originalTopic).To(BeEmpty())
 				})
 			})
+
+			Context("when a topic has a per-topic MaxRetries of 1 and the global dlqThreshold is higher", func() {
+				var messageID string
+
+				BeforeEach(func() {
+					// Global dlqThreshold = 5 — without the fix the message would
+					// not be promoted on the first nack. Per-topic MaxRetries = 1
+					// should take precedence and trigger DLQ promotion immediately.
+					service = queue.NewService(pool, 30*time.Second, 10, 0, 5, false, queue.NoopRecorder{})
+
+					perTopicRetries := 1
+					err := service.UpsertTopicConfig(ctx, queue.TopicConfig{
+						Topic:      "payments",
+						MaxRetries: &perTopicRetries,
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					messageID, err = service.Enqueue(ctx, "payments", []byte("charge"), nil, nil)
+					Expect(err).NotTo(HaveOccurred())
+
+					_, err = service.Dequeue(ctx, "payments", 0)
+					Expect(err).NotTo(HaveOccurred())
+
+					err = service.Nack(ctx, messageID, "card declined")
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				It("should promote the message to payments.dlq after the first nack", func() {
+					var topic string
+					err := pool.QueryRow(ctx,
+						`SELECT topic FROM messages WHERE id = $1`, messageID,
+					).Scan(&topic)
+
+					Expect(err).NotTo(HaveOccurred())
+					Expect(topic).To(Equal("payments.dlq"))
+				})
+			})
+
+			Context("when a topic has a per-topic MaxRetries of 3 and the global dlqThreshold is lower (1)", func() {
+				var messageID string
+
+				BeforeEach(func() {
+					// Global dlqThreshold = 1 — without the fix the message would
+					// be promoted after the first nack. Per-topic MaxRetries = 3
+					// should override and allow two retries before DLQ promotion.
+					service = queue.NewService(pool, 30*time.Second, 10, 0, 1, false, queue.NoopRecorder{})
+
+					perTopicRetries := 3
+					err := service.UpsertTopicConfig(ctx, queue.TopicConfig{
+						Topic:      "notifications",
+						MaxRetries: &perTopicRetries,
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					messageID, err = service.Enqueue(ctx, "notifications", []byte("send email"), nil, nil)
+					Expect(err).NotTo(HaveOccurred())
+
+					_, err = service.Dequeue(ctx, "notifications", 0)
+					Expect(err).NotTo(HaveOccurred())
+
+					// First nack — should NOT promote (retry_count 1 < 3).
+					err = service.Nack(ctx, messageID, "smtp timeout")
+					Expect(err).NotTo(HaveOccurred())
+				})
+
+				It("should keep the message on the original topic after the first nack", func() {
+					var topic string
+					err := pool.QueryRow(ctx,
+						`SELECT topic FROM messages WHERE id = $1`, messageID,
+					).Scan(&topic)
+
+					Expect(err).NotTo(HaveOccurred())
+					Expect(topic).To(Equal("notifications"))
+				})
+
+				It("should promote to DLQ on the third nack (retry_count reaches 3)", func() {
+					// Second nack.
+					_, err := service.Dequeue(ctx, "notifications", 0)
+					Expect(err).NotTo(HaveOccurred())
+					err = service.Nack(ctx, messageID, "smtp timeout")
+					Expect(err).NotTo(HaveOccurred())
+
+					// Third nack — retry_count = 3 equals per-topic MaxRetries.
+					_, err = service.Dequeue(ctx, "notifications", 0)
+					Expect(err).NotTo(HaveOccurred())
+					err = service.Nack(ctx, messageID, "smtp timeout")
+					Expect(err).NotTo(HaveOccurred())
+
+					var topic string
+					err = pool.QueryRow(ctx,
+						`SELECT topic FROM messages WHERE id = $1`, messageID,
+					).Scan(&topic)
+
+					Expect(err).NotTo(HaveOccurred())
+					Expect(topic).To(Equal("notifications.dlq"))
+				})
+			})
 		})
 
 		// --- Requeue ---
@@ -650,6 +747,52 @@ var _ = Describe("Queue Service", func() {
 					msg, err := service.Dequeue(ctx, "shipments", 0)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(msg.ID).To(Equal(messageID))
+				})
+			})
+
+			Context("when the original topic has a per-topic MaxRetries configured", func() {
+				var messageID string
+
+				BeforeEach(func() {
+					// Per-topic MaxRetries = 1, global dlqThreshold = 10.
+					// One nack promotes to DLQ (per-topic wins over global).
+					// After requeue, max_retries should be restored to the per-topic value (1).
+					service = queue.NewService(pool, 30*time.Second, 10, 0, 10, false, queue.NoopRecorder{})
+
+					perTopicRetries := 1
+					err := service.UpsertTopicConfig(ctx, queue.TopicConfig{
+						Topic:      "refunds",
+						MaxRetries: &perTopicRetries,
+					})
+					Expect(err).NotTo(HaveOccurred())
+
+					messageID, err = service.Enqueue(ctx, "refunds", []byte("process refund"), nil, nil)
+					Expect(err).NotTo(HaveOccurred())
+
+					_, err = service.Dequeue(ctx, "refunds", 0)
+					Expect(err).NotTo(HaveOccurred())
+
+					err = service.Nack(ctx, messageID, "gateway error")
+					Expect(err).NotTo(HaveOccurred())
+
+					// Confirm it landed in the DLQ.
+					var topic string
+					err = pool.QueryRow(ctx, `SELECT topic FROM messages WHERE id = $1`, messageID).Scan(&topic)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(topic).To(Equal("refunds.dlq"))
+				})
+
+				It("should restore max_retries to the per-topic value after requeue", func() {
+					err := service.Requeue(ctx, messageID)
+					Expect(err).NotTo(HaveOccurred())
+
+					var maxRetries int
+					err = pool.QueryRow(ctx,
+						`SELECT max_retries FROM messages WHERE id = $1`, messageID,
+					).Scan(&maxRetries)
+
+					Expect(err).NotTo(HaveOccurred())
+					Expect(maxRetries).To(Equal(1))
 				})
 			})
 


### PR DESCRIPTION
## Summary

- `Nack`, `NackForGroup`, and `Requeue` in `lifecycle.go` were using the global `dlqThreshold` for DLQ promotion decisions, ignoring any `MaxRetries` set on a topic's `TopicConfig`
- New helper `effectiveDLQThreshold` checks per-topic config first, falling back to the global threshold
- `Requeue` now also restores `max_retries` from the same per-topic value so re-enqueued messages have the correct retry budget

## Test plan

- [x] Tests pass: per-topic MaxRetries = 1 overrides global dlqThreshold = 10 → DLQ on first nack
- [x] Tests pass: per-topic MaxRetries = 3 overrides global dlqThreshold = 1 → two retries before DLQ promotion
- [x] Tests pass: Requeue restores `max_retries` to per-topic value, not global threshold
- [x] All existing 147 tests continue to pass