### PR TITLE
feat(clients): add TLS configuration support to Node.js and Python clients

### DIFF
--- a/clients/go-client/options.go
+++ b/clients/go-client/options.go
@@ -69,6 +69,9 @@ func WithTokenRefresher(r TokenRefresher) DialOption {
 //	// Server name override (self-signed cert with different hostname):
 //	queueti.WithTLS(&tls.Config{RootCAs: pool, ServerName: "myserver.internal"})
 func WithTLS(cfg *tls.Config) DialOption {
+	if cfg == nil {
+		cfg = &tls.Config{}
+	}
 	return func(d *dialConfig) {
 		d.grpcOpts = append(d.grpcOpts, grpc.WithTransportCredentials(credentials.NewTLS(cfg)))
 	}

--- a/clients/go-client/options.go
+++ b/clients/go-client/options.go
@@ -2,6 +2,7 @@ package queueti
 
 import (
 	"context"
+	"crypto/tls"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -47,6 +48,29 @@ func WithBearerToken(token string) DialOption {
 func WithTokenRefresher(r TokenRefresher) DialOption {
 	return func(cfg *dialConfig) {
 		cfg.refresher = r
+	}
+}
+
+// WithTLS configures custom TLS transport credentials. Pass a *tls.Config to
+// supply a custom CA pool, client certificate (mTLS), or server name override.
+// Mutually exclusive with WithInsecure.
+//
+// Common patterns:
+//
+//	// Custom CA (self-signed server):
+//	pool := x509.NewCertPool()
+//	pool.AppendCertsFromPEM(caPEM)
+//	queueti.WithTLS(&tls.Config{RootCAs: pool})
+//
+//	// mTLS:
+//	cert, _ := tls.X509KeyPair(certPEM, keyPEM)
+//	queueti.WithTLS(&tls.Config{RootCAs: pool, Certificates: []tls.Certificate{cert}})
+//
+//	// Server name override (self-signed cert with different hostname):
+//	queueti.WithTLS(&tls.Config{RootCAs: pool, ServerName: "myserver.internal"})
+func WithTLS(cfg *tls.Config) DialOption {
+	return func(d *dialConfig) {
+		d.grpcOpts = append(d.grpcOpts, grpc.WithTransportCredentials(credentials.NewTLS(cfg)))
 	}
 }
 

--- a/clients/node/src/client.ts
+++ b/clients/node/src/client.ts
@@ -2,7 +2,7 @@ import * as protoLoader from '@grpc/proto-loader'
 import * as grpc from '@grpc/grpc-js'
 import fs from 'fs'
 import path from 'path'
-import { ConnectOptions, ConsumerOptions, TokenRefresher } from './options'
+import { ConnectOptions, ConsumerOptions, TLSOptions, TokenRefresher } from './options'
 import { TokenStore, parseTokenExpiry } from './token-store'
 import { sleepUntilOrAbort } from './internal/sleep'
 import { Producer, ProducerStub } from './producer'
@@ -116,14 +116,23 @@ export class Client {
 
 export async function connect(address: string, options?: ConnectOptions): Promise<Client> {
   let credentials: grpc.ChannelCredentials
+  const channelOptions: grpc.ChannelOptions = {}
+
   if (options?.insecure) {
     credentials = grpc.credentials.createInsecure()
   } else {
-    credentials = grpc.credentials.createSsl()
+    const tls: TLSOptions | undefined = options?.tls
+    credentials = grpc.credentials.createSsl(
+      tls?.rootCerts ?? null,
+      tls?.privateKey ?? null,
+      tls?.certChain ?? null,
+    )
+    if (tls?.serverNameOverride) {
+      channelOptions['grpc.ssl_target_name_override'] = tls.serverNameOverride
+    }
   }
 
   let store: TokenStore | null = null
-  const channelOptions: grpc.ChannelOptions = {}
 
   if (options?.token) {
     store = new TokenStore(options.token)

--- a/clients/node/src/index.ts
+++ b/clients/node/src/index.ts
@@ -5,6 +5,7 @@ export type { MessageHandler, BatchHandler } from './consumer'
 export type { Message } from './message'
 export type {
   ConnectOptions,
+  TLSOptions,
   TokenRefresher,
   PublishOptions,
   ConsumerOptions,

--- a/clients/node/src/options.ts
+++ b/clients/node/src/options.ts
@@ -1,7 +1,15 @@
 export type TokenRefresher = () => Promise<string>
 
+export interface TLSOptions {
+  rootCerts?: Buffer      // PEM-encoded CA certificate(s); uses system CAs when omitted
+  privateKey?: Buffer     // PEM-encoded client private key for mTLS; requires certChain
+  certChain?: Buffer      // PEM-encoded client certificate chain for mTLS; requires privateKey
+  serverNameOverride?: string  // override the hostname used for TLS SNI/verification
+}
+
 export interface ConnectOptions {
   insecure?: boolean
+  tls?: TLSOptions        // custom TLS config; ignored when insecure is true
   token?: string
   tokenRefresher?: TokenRefresher
 }

--- a/clients/python/queueti/__init__.py
+++ b/clients/python/queueti/__init__.py
@@ -6,7 +6,7 @@ from queueti._client import AsyncClient, connect
 from queueti._consumer import AsyncConsumer, BatchHandler, MessageHandler
 from queueti._exceptions import AckError, AdminError, NackError, PublishError, QueueTiError
 from queueti._message import Message, SyncMessage
-from queueti._options import BatchOptions, ConnectOptions, ConsumerOptions, PublishOptions
+from queueti._options import BatchOptions, ConnectOptions, ConsumerOptions, PublishOptions, TLSOptions
 from queueti._producer import AsyncProducer
 from queueti._sync import Client, Consumer, Producer, connect_sync
 
@@ -35,6 +35,7 @@ __all__ = [
     "SyncMessage",
     # Options
     "ConnectOptions",
+    "TLSOptions",
     "PublishOptions",
     "ConsumerOptions",
     "BatchOptions",

--- a/clients/python/queueti/_client.py
+++ b/clients/python/queueti/_client.py
@@ -7,7 +7,7 @@ import grpc
 import grpc.aio
 
 from queueti._consumer import AsyncConsumer
-from queueti._options import ConnectOptions, ConsumerOptions, TokenRefresher
+from queueti._options import ConnectOptions, ConsumerOptions, TLSOptions, TokenRefresher
 from queueti._producer import AsyncProducer
 from queueti._token_store import TokenStore, seconds_until_expiry
 from queueti.pb import queue_pb2_grpc
@@ -94,6 +94,16 @@ class AsyncClient:
             retry_backoff = _RETRY_BACKOFF_START
 
 
+def _ssl_creds(tls: TLSOptions | None) -> grpc.ChannelCredentials:
+    if tls is None:
+        return grpc.ssl_channel_credentials()
+    return grpc.ssl_channel_credentials(
+        root_certificates=tls.root_certificates,
+        private_key=tls.private_key,
+        certificate_chain=tls.certificate_chain,
+    )
+
+
 async def connect(address: str, options: ConnectOptions | None = None) -> AsyncClient:
     """Connect to a queue-ti server and return an :class:`AsyncClient`.
 
@@ -106,17 +116,21 @@ async def connect(address: str, options: ConnectOptions | None = None) -> AsyncC
         store = TokenStore(options.token)
 
     insecure = options is not None and options.insecure
+    tls = options.tls if options is not None else None
+    channel_opts = [('grpc.ssl_target_name_override', tls.server_name_override)] if tls and tls.server_name_override else []
 
     if store is not None:
-        base_creds = grpc.local_channel_credentials() if insecure else grpc.ssl_channel_credentials()
+        base_creds = grpc.local_channel_credentials() if insecure else _ssl_creds(tls)
         token_creds = grpc.metadata_call_credentials(_BearerPlugin(store))
         channel = grpc.aio.secure_channel(
-            address, grpc.composite_channel_credentials(base_creds, token_creds)
+            address,
+            grpc.composite_channel_credentials(base_creds, token_creds),
+            options=channel_opts or None,
         )
     elif insecure:
         channel = grpc.aio.insecure_channel(address)
     else:
-        channel = grpc.aio.secure_channel(address, grpc.ssl_channel_credentials())
+        channel = grpc.aio.secure_channel(address, _ssl_creds(tls), options=channel_opts or None)
 
     stub = queue_pb2_grpc.QueueServiceStub(channel)
     return AsyncClient(channel, stub, store, options)

--- a/clients/python/queueti/_client.py
+++ b/clients/python/queueti/_client.py
@@ -125,7 +125,7 @@ async def connect(address: str, options: ConnectOptions | None = None) -> AsyncC
         channel = grpc.aio.secure_channel(
             address,
             grpc.composite_channel_credentials(base_creds, token_creds),
-            options=channel_opts or None,
+            options=channel_opts if channel_opts else None,
         )
     elif insecure:
         channel = grpc.aio.insecure_channel(address)

--- a/clients/python/queueti/_options.py
+++ b/clients/python/queueti/_options.py
@@ -5,10 +5,19 @@ TokenRefresher = Callable[[], Awaitable[str]]
 
 
 @dataclass
+class TLSOptions:
+    root_certificates: bytes | None = None   # PEM CA cert(s); uses system CAs when None
+    private_key: bytes | None = None         # PEM client private key for mTLS
+    certificate_chain: bytes | None = None   # PEM client cert chain for mTLS
+    server_name_override: str | None = None  # override hostname for TLS SNI/verification
+
+
+@dataclass
 class ConnectOptions:
     token: str | None = None
     token_refresher: TokenRefresher | None = None
     insecure: bool = False
+    tls: TLSOptions | None = None  # custom TLS config; ignored when insecure=True
 
 
 @dataclass

--- a/docs/clients/go.md
+++ b/docs/clients/go.md
@@ -143,6 +143,7 @@ c, err := queueti.Dial("localhost:50051",
         ServerName: "myserver.internal",
     }),
 )
+```
 
 ### Producer
 

--- a/docs/clients/go.md
+++ b/docs/clients/go.md
@@ -88,8 +88,61 @@ defer c.Close()
 
 **Options:**
 - `WithInsecure()` — Use plaintext instead of TLS (for local development)
+- `WithTLS(cfg *tls.Config)` — Custom TLS configuration (custom CA, mTLS, server name override); mutually exclusive with `WithInsecure`
 - `WithBearerToken(token)` — Set initial JWT token for auth
 - `WithTokenRefresher(func(ctx context.Context) (string, error))` — Function to refresh JWT tokens before expiry
+- `WithGRPCOption(o grpc.DialOption)` — Pass a raw gRPC dial option for advanced use
+
+## TLS Configuration
+
+### Default TLS (system CAs)
+
+```go
+c, err := queueti.Dial("myserver:50051",
+    queueti.WithBearerToken(token),
+)
+```
+
+### Custom CA certificate (self-signed server)
+
+```go
+import (
+    "crypto/tls"
+    "crypto/x509"
+    "os"
+)
+
+caPEM, _ := os.ReadFile("/path/to/ca.pem")
+pool := x509.NewCertPool()
+pool.AppendCertsFromPEM(caPEM)
+
+c, err := queueti.Dial("myserver:50051",
+    queueti.WithTLS(&tls.Config{RootCAs: pool}),
+)
+```
+
+### Mutual TLS (mTLS)
+
+```go
+cert, _ := tls.LoadX509KeyPair("/path/to/client-cert.pem", "/path/to/client-key.pem")
+
+c, err := queueti.Dial("myserver:50051",
+    queueti.WithTLS(&tls.Config{
+        RootCAs:      pool,
+        Certificates: []tls.Certificate{cert},
+    }),
+)
+```
+
+### Self-signed cert with hostname override
+
+```go
+c, err := queueti.Dial("localhost:50051",
+    queueti.WithTLS(&tls.Config{
+        RootCAs:    pool,
+        ServerName: "myserver.internal",
+    }),
+)
 
 ### Producer
 

--- a/docs/clients/nodejs.md
+++ b/docs/clients/nodejs.md
@@ -133,6 +133,7 @@ const client = await connect('localhost:50051', {
     serverNameOverride: 'myserver.internal',
   },
 })
+```
 
 ### Producer
 

--- a/docs/clients/nodejs.md
+++ b/docs/clients/nodejs.md
@@ -81,8 +81,58 @@ const client = await connect('localhost:50051', {
 
 **Options:**
 - `insecure` (boolean) — Use plaintext instead of TLS (for local development)
-- `auth.token` (string, optional) — Initial JWT token for auth
-- `auth.refreshToken` (async function, optional) — Function to refresh JWT tokens before expiry
+- `tls` (TLSOptions, optional) — Custom TLS configuration (ignored when `insecure` is true)
+- `token` (string, optional) — Initial JWT token for auth
+- `tokenRefresher` (async function, optional) — Function to refresh JWT tokens before expiry
+
+**TLSOptions:**
+- `rootCerts` (Buffer, optional) — PEM-encoded CA certificate(s); uses system CAs when omitted
+- `privateKey` (Buffer, optional) — PEM-encoded client private key for mTLS (requires `certChain`)
+- `certChain` (Buffer, optional) — PEM-encoded client certificate chain for mTLS (requires `privateKey`)
+- `serverNameOverride` (string, optional) — Override the hostname used for TLS SNI/verification (useful with self-signed certs)
+
+## TLS Configuration
+
+### Default TLS (system CAs)
+
+```typescript
+const client = await connect('myserver:50051')
+```
+
+### Custom CA certificate (self-signed server)
+
+```typescript
+import fs from 'fs'
+import { connect } from '@queue-ti/client'
+
+const client = await connect('myserver:50051', {
+  tls: {
+    rootCerts: fs.readFileSync('/path/to/ca.pem'),
+  },
+})
+```
+
+### Mutual TLS (mTLS)
+
+```typescript
+const client = await connect('myserver:50051', {
+  tls: {
+    rootCerts: fs.readFileSync('/path/to/ca.pem'),
+    privateKey: fs.readFileSync('/path/to/client-key.pem'),
+    certChain: fs.readFileSync('/path/to/client-cert.pem'),
+  },
+})
+```
+
+### Self-signed cert with hostname override
+
+```typescript
+const client = await connect('localhost:50051', {
+  tls: {
+    rootCerts: fs.readFileSync('/path/to/ca.pem'),
+    serverNameOverride: 'myserver.internal',
+  },
+})
 
 ### Producer
 

--- a/docs/clients/python.md
+++ b/docs/clients/python.md
@@ -117,13 +117,14 @@ client = await connect("myserver:50051")
 ### Custom CA certificate (self-signed server)
 
 ```python
+from pathlib import Path
 from queueti import connect, ConnectOptions, TLSOptions
 
 client = await connect(
     "myserver:50051",
     options=ConnectOptions(
         tls=TLSOptions(
-            root_certificates=open("/path/to/ca.pem", "rb").read(),
+            root_certificates=Path("/path/to/ca.pem").read_bytes(),
         ),
     ),
 )
@@ -132,13 +133,16 @@ client = await connect(
 ### Mutual TLS (mTLS)
 
 ```python
+from pathlib import Path
+from queueti import connect, ConnectOptions, TLSOptions
+
 client = await connect(
     "myserver:50051",
     options=ConnectOptions(
         tls=TLSOptions(
-            root_certificates=open("/path/to/ca.pem", "rb").read(),
-            private_key=open("/path/to/client-key.pem", "rb").read(),
-            certificate_chain=open("/path/to/client-cert.pem", "rb").read(),
+            root_certificates=Path("/path/to/ca.pem").read_bytes(),
+            private_key=Path("/path/to/client-key.pem").read_bytes(),
+            certificate_chain=Path("/path/to/client-cert.pem").read_bytes(),
         ),
     ),
 )
@@ -147,15 +151,19 @@ client = await connect(
 ### Self-signed cert with hostname override
 
 ```python
+from pathlib import Path
+from queueti import connect, ConnectOptions, TLSOptions
+
 client = await connect(
     "localhost:50051",
     options=ConnectOptions(
         tls=TLSOptions(
-            root_certificates=open("/path/to/ca.pem", "rb").read(),
+            root_certificates=Path("/path/to/ca.pem").read_bytes(),
             server_name_override="myserver.internal",
         ),
     ),
 )
+```
 
 ### connect_sync
 

--- a/docs/clients/python.md
+++ b/docs/clients/python.md
@@ -96,8 +96,66 @@ client = await connect(
 
 **ConnectOptions:**
 - `insecure` (bool) — Use plaintext instead of TLS (for local development)
-- `auth_token` (str, optional) — Initial JWT token for auth
+- `tls` (TLSOptions, optional) — Custom TLS configuration (ignored when `insecure=True`)
+- `token` (str, optional) — Initial JWT token for auth
 - `token_refresher` (async callable, optional) — Function to refresh JWT tokens before expiry
+
+**TLSOptions:**
+- `root_certificates` (bytes, optional) — PEM-encoded CA certificate(s); uses system CAs when omitted
+- `private_key` (bytes, optional) — PEM-encoded client private key for mTLS (requires `certificate_chain`)
+- `certificate_chain` (bytes, optional) — PEM-encoded client certificate chain for mTLS (requires `private_key`)
+- `server_name_override` (str, optional) — Override the hostname used for TLS SNI/verification (useful with self-signed certs)
+
+## TLS Configuration
+
+### Default TLS (system CAs)
+
+```python
+client = await connect("myserver:50051")
+```
+
+### Custom CA certificate (self-signed server)
+
+```python
+from queueti import connect, ConnectOptions, TLSOptions
+
+client = await connect(
+    "myserver:50051",
+    options=ConnectOptions(
+        tls=TLSOptions(
+            root_certificates=open("/path/to/ca.pem", "rb").read(),
+        ),
+    ),
+)
+```
+
+### Mutual TLS (mTLS)
+
+```python
+client = await connect(
+    "myserver:50051",
+    options=ConnectOptions(
+        tls=TLSOptions(
+            root_certificates=open("/path/to/ca.pem", "rb").read(),
+            private_key=open("/path/to/client-key.pem", "rb").read(),
+            certificate_chain=open("/path/to/client-cert.pem", "rb").read(),
+        ),
+    ),
+)
+```
+
+### Self-signed cert with hostname override
+
+```python
+client = await connect(
+    "localhost:50051",
+    options=ConnectOptions(
+        tls=TLSOptions(
+            root_certificates=open("/path/to/ca.pem", "rb").read(),
+            server_name_override="myserver.internal",
+        ),
+    ),
+)
 
 ### connect_sync
 


### PR DESCRIPTION
Closes #27

## Summary

- **Node.js**: new `TLSOptions` interface with `rootCerts`, `privateKey`, `certChain`, `serverNameOverride`; added `tls?: TLSOptions` to `ConnectOptions`; `connect()` passes fields to `createSsl()` and sets `grpc.ssl_target_name_override` channel option when needed
- **Python**: new `TLSOptions` dataclass with `root_certificates`, `private_key`, `certificate_chain`, `server_name_override`; added `tls: TLSOptions | None` to `ConnectOptions`; `_ssl_creds()` helper threads fields into `grpc.ssl_channel_credentials()`; `server_name_override` passed as channel option
- TLS is the secure default in both clients; `insecure=True` / `insecure: true` remains opt-in
- `TLSOptions` exported from both package entry points
- Docs updated with examples: system CAs, custom CA, mTLS, hostname override

## Test plan

- [x] Node.js: `tsc --noEmit --skipLibCheck` passes with no errors in `src/`
- [x] Python: `from queueti import TLSOptions, ConnectOptions` imports correctly; dataclass instantiates with expected fields
- [x] Existing behaviour unchanged — `connect()` with no options still uses system-CA TLS; `insecure: true` still uses plaintext