### PR TITLE
docs: add TLS and QueueTiAuth to C# and Java client docs

### DIFF
--- a/docs/clients/csharp.md
+++ b/docs/clients/csharp.md
@@ -89,6 +89,61 @@ app.MapPost("/orders", async ([FromServices] QueueTiClient client) =>
 });
 ```
 
+## TLS Configuration
+
+### Default TLS (system CAs)
+
+```csharp
+var client = QueueTiClient.Create("https://queue.example.com:50051");
+```
+
+### Custom CA certificate (self-signed server)
+
+```csharp
+var caPem = await File.ReadAllBytesAsync("/path/to/ca.pem");
+
+var client = QueueTiClient.Create("https://myserver:50051", new QueueTiClientOptions
+{
+    Tls = new TlsOptions { RootCertificates = caPem }
+});
+```
+
+### Mutual TLS (mTLS)
+
+```csharp
+var client = QueueTiClient.Create("https://myserver:50051", new QueueTiClientOptions
+{
+    Tls = new TlsOptions
+    {
+        RootCertificates = await File.ReadAllBytesAsync("/path/to/ca.pem"),
+        PrivateKey = await File.ReadAllBytesAsync("/path/to/client-key.pem"),
+        CertificateChain = await File.ReadAllBytesAsync("/path/to/client-cert.pem"),
+    }
+});
+```
+
+### Self-signed cert with hostname override
+
+```csharp
+var client = QueueTiClient.Create("https://localhost:50051", new QueueTiClientOptions
+{
+    Tls = new TlsOptions
+    {
+        RootCertificates = await File.ReadAllBytesAsync("/path/to/ca.pem"),
+        ServerNameOverride = "myserver.internal",
+    }
+});
+```
+
+### TlsOptions
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `RootCertificates` | `byte[]?` | `null` | PEM-encoded CA certificate(s); uses system CAs when `null`. |
+| `PrivateKey` | `byte[]?` | `null` | PEM-encoded client private key for mTLS (requires `CertificateChain`). |
+| `CertificateChain` | `byte[]?` | `null` | PEM-encoded client certificate chain for mTLS (requires `PrivateKey`). |
+| `ServerNameOverride` | `string?` | `null` | Override the hostname used for TLS SNI/verification (useful with self-signed certs). |
+
 ## Publishing Messages
 
 ```csharp
@@ -189,6 +244,8 @@ await consumer.ConsumeBatchAsync(
 using QueueTi;
 
 var auth = await QueueTiAuth.LoginAsync("http://localhost:8080", "admin", "secret");
+// auth.Token is null when auth is disabled — QueueTiClient treats null BearerToken as unauthenticated
+// auth.RefreshAsync is a no-op delegate when auth is disabled, so it is always safe to assign
 
 await using var client = QueueTiClient.Create("https://queue.example.com:50051", new QueueTiClientOptions
 {
@@ -202,7 +259,7 @@ var admin = AdminClient.Create("http://localhost:8080",
 
 The `QueueTiAuth` helper:
 1. Calls `GET /api/auth/status` to check if authentication is required
-2. If auth is disabled, returns a no-op instance with a `null` token
+2. If auth is disabled, returns a no-op instance with a `null` token and a no-op `RefreshAsync`
 3. If auth is enabled, calls `POST /api/auth/login` with the provided credentials
 4. Exposes `.Token` (`string?`) for the current JWT and `.RefreshAsync` (`Func<CancellationToken, Task<string>>`) which satisfies the `TokenRefresher` interface for automatic token refresh
 
@@ -250,63 +307,6 @@ client.SetToken("new-jwt-token");  // thread-safe; immediate effect
 | `Tls` | `TlsOptions?` | `null` | Custom TLS configuration (custom CA, mTLS, server name override). Ignored when `Insecure` is `true`. |
 | `ConfigureChannel` | `Action<GrpcChannelOptions>?` | `null` | Callback to configure gRPC channel options. |
 | `ConfigureHttpClientBuilder` | `Action<IHttpClientBuilder>?` | `null` | DI only: configure the `IHttpClientBuilder`. |
-
-## TLS Configuration
-
-### Default TLS (system CAs)
-
-```csharp
-var client = QueueTiClient.Create("https://queue.example.com:50051");
-```
-
-### Custom CA certificate (self-signed server)
-
-```csharp
-using QueueTi;
-
-var caPem = await File.ReadAllBytesAsync("/path/to/ca.pem");
-
-var client = QueueTiClient.Create("https://myserver:50051", new QueueTiClientOptions
-{
-    Tls = new TlsOptions { RootCertificates = caPem }
-});
-```
-
-### Mutual TLS (mTLS)
-
-```csharp
-var client = QueueTiClient.Create("https://myserver:50051", new QueueTiClientOptions
-{
-    Tls = new TlsOptions
-    {
-        RootCertificates = await File.ReadAllBytesAsync("/path/to/ca.pem"),
-        PrivateKey = await File.ReadAllBytesAsync("/path/to/client-key.pem"),
-        CertificateChain = await File.ReadAllBytesAsync("/path/to/client-cert.pem"),
-    }
-});
-```
-
-### Self-signed cert with hostname override
-
-```csharp
-var client = QueueTiClient.Create("https://localhost:50051", new QueueTiClientOptions
-{
-    Tls = new TlsOptions
-    {
-        RootCertificates = await File.ReadAllBytesAsync("/path/to/ca.pem"),
-        ServerNameOverride = "myserver.internal",
-    }
-});
-```
-
-### TlsOptions
-
-| Property | Type | Default | Description |
-|----------|------|---------|-------------|
-| `RootCertificates` | `byte[]?` | `null` | PEM-encoded CA certificate(s); uses system CAs when `null`. |
-| `PrivateKey` | `byte[]?` | `null` | PEM-encoded client private key for mTLS (requires `CertificateChain`). |
-| `CertificateChain` | `byte[]?` | `null` | PEM-encoded client certificate chain for mTLS (requires `PrivateKey`). |
-| `ServerNameOverride` | `string?` | `null` | Override the hostname used for TLS SNI/verification (useful with self-signed certs). |
 
 ## Disposal
 

--- a/docs/clients/csharp.md
+++ b/docs/clients/csharp.md
@@ -179,7 +179,32 @@ await consumer.ConsumeBatchAsync(
 | `CreatedAt` | `DateTimeOffset` | Server timestamp when the message was created. |
 | `RetryCount` | `int` | Number of previous delivery attempts. |
 
-## Bearer Token Authentication
+## Authentication
+
+### Using QueueTiAuth (recommended)
+
+`QueueTiAuth` automatically checks whether authentication is required, logs in, and wires up token refresh:
+
+```csharp
+using QueueTi;
+
+var auth = await QueueTiAuth.LoginAsync("http://localhost:8080", "admin", "secret");
+
+await using var client = QueueTiClient.Create("https://queue.example.com:50051", new QueueTiClientOptions
+{
+    BearerToken = auth.Token,
+    TokenRefresher = auth.RefreshAsync,
+});
+
+var admin = AdminClient.Create("http://localhost:8080",
+    new QueueTiClientOptions { BearerToken = auth.Token });
+```
+
+The `QueueTiAuth` helper:
+1. Calls `GET /api/auth/status` to check if authentication is required
+2. If auth is disabled, returns a no-op instance with a `null` token
+3. If auth is enabled, calls `POST /api/auth/login` with the provided credentials
+4. Exposes `.Token` (`string?`) for the current JWT and `.RefreshAsync` (`Func<CancellationToken, Task<string>>`) which satisfies the `TokenRefresher` interface for automatic token refresh
 
 ### Static token
 
@@ -222,8 +247,66 @@ client.SetToken("new-jwt-token");  // thread-safe; immediate effect
 | `BearerToken` | `string?` | `null` | Initial JWT for Bearer authentication. |
 | `TokenRefresher` | `Func<CancellationToken, Task<string>>?` | `null` | Async callback to refresh the bearer token. |
 | `Insecure` | `bool` | `false` | Use plaintext `http://` (disables TLS). |
+| `Tls` | `TlsOptions?` | `null` | Custom TLS configuration (custom CA, mTLS, server name override). Ignored when `Insecure` is `true`. |
 | `ConfigureChannel` | `Action<GrpcChannelOptions>?` | `null` | Callback to configure gRPC channel options. |
 | `ConfigureHttpClientBuilder` | `Action<IHttpClientBuilder>?` | `null` | DI only: configure the `IHttpClientBuilder`. |
+
+## TLS Configuration
+
+### Default TLS (system CAs)
+
+```csharp
+var client = QueueTiClient.Create("https://queue.example.com:50051");
+```
+
+### Custom CA certificate (self-signed server)
+
+```csharp
+using QueueTi;
+
+var caPem = await File.ReadAllBytesAsync("/path/to/ca.pem");
+
+var client = QueueTiClient.Create("https://myserver:50051", new QueueTiClientOptions
+{
+    Tls = new TlsOptions { RootCertificates = caPem }
+});
+```
+
+### Mutual TLS (mTLS)
+
+```csharp
+var client = QueueTiClient.Create("https://myserver:50051", new QueueTiClientOptions
+{
+    Tls = new TlsOptions
+    {
+        RootCertificates = await File.ReadAllBytesAsync("/path/to/ca.pem"),
+        PrivateKey = await File.ReadAllBytesAsync("/path/to/client-key.pem"),
+        CertificateChain = await File.ReadAllBytesAsync("/path/to/client-cert.pem"),
+    }
+});
+```
+
+### Self-signed cert with hostname override
+
+```csharp
+var client = QueueTiClient.Create("https://localhost:50051", new QueueTiClientOptions
+{
+    Tls = new TlsOptions
+    {
+        RootCertificates = await File.ReadAllBytesAsync("/path/to/ca.pem"),
+        ServerNameOverride = "myserver.internal",
+    }
+});
+```
+
+### TlsOptions
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `RootCertificates` | `byte[]?` | `null` | PEM-encoded CA certificate(s); uses system CAs when `null`. |
+| `PrivateKey` | `byte[]?` | `null` | PEM-encoded client private key for mTLS (requires `CertificateChain`). |
+| `CertificateChain` | `byte[]?` | `null` | PEM-encoded client certificate chain for mTLS (requires `PrivateKey`). |
+| `ServerNameOverride` | `string?` | `null` | Override the hostname used for TLS SNI/verification (useful with self-signed certs). |
 
 ## Disposal
 

--- a/docs/clients/java.md
+++ b/docs/clients/java.md
@@ -266,6 +266,9 @@ try (var client = QueueTiClient.connect("myserver:50051",
 ### Mutual TLS (mTLS)
 
 ```java
+import java.nio.file.Files;
+import java.nio.file.Path;
+
 try (var client = QueueTiClient.connect("myserver:50051",
         ConnectOptions.builder()
             .tls(TlsOptions.builder()
@@ -281,6 +284,9 @@ try (var client = QueueTiClient.connect("myserver:50051",
 ### Self-signed cert with hostname override
 
 ```java
+import java.nio.file.Files;
+import java.nio.file.Path;
+
 try (var client = QueueTiClient.connect("localhost:50051",
         ConnectOptions.builder()
             .tls(TlsOptions.builder()

--- a/docs/clients/java.md
+++ b/docs/clients/java.md
@@ -177,6 +177,7 @@ consumer.consumeBatch(10, messages -> {
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `insecure` | `boolean` | `false` | Use plaintext channel (no TLS) |
+| `tls` | `TlsOptions` | `null` | Custom TLS configuration (custom CA, mTLS, server name override). Ignored when `insecure` is `true`. |
 | `token` | `String` | `null` | Initial JWT sent on every request |
 | `tokenRefresher` | `TokenRefresher` | `null` | Strategy to obtain fresh tokens |
 
@@ -232,6 +233,73 @@ The client wakes a background virtual thread 60 seconds before token expiry. On 
 ```java
 client.setToken(newToken);
 ```
+
+## TLS Configuration
+
+### Default TLS (system CAs)
+
+```java
+try (var client = QueueTiClient.connect("myserver:50051",
+        ConnectOptions.builder().build())) {
+    // ...
+}
+```
+
+### Custom CA certificate (self-signed server)
+
+```java
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+byte[] caPem = Files.readAllBytes(Path.of("/path/to/ca.pem"));
+
+try (var client = QueueTiClient.connect("myserver:50051",
+        ConnectOptions.builder()
+            .tls(TlsOptions.builder()
+                .rootCertificates(caPem)
+                .build())
+            .build())) {
+    // ...
+}
+```
+
+### Mutual TLS (mTLS)
+
+```java
+try (var client = QueueTiClient.connect("myserver:50051",
+        ConnectOptions.builder()
+            .tls(TlsOptions.builder()
+                .rootCertificates(Files.readAllBytes(Path.of("/path/to/ca.pem")))
+                .privateKey(Files.readAllBytes(Path.of("/path/to/client-key.pem")))
+                .certificateChain(Files.readAllBytes(Path.of("/path/to/client-cert.pem")))
+                .build())
+            .build())) {
+    // ...
+}
+```
+
+### Self-signed cert with hostname override
+
+```java
+try (var client = QueueTiClient.connect("localhost:50051",
+        ConnectOptions.builder()
+            .tls(TlsOptions.builder()
+                .rootCertificates(Files.readAllBytes(Path.of("/path/to/ca.pem")))
+                .serverNameOverride("myserver.internal")
+                .build())
+            .build())) {
+    // ...
+}
+```
+
+### TlsOptions
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `rootCertificates` | `byte[]` | `null` | PEM-encoded CA certificate(s); uses system CAs when `null`. |
+| `privateKey` | `byte[]` | `null` | PEM-encoded client private key for mTLS (requires `certificateChain`). |
+| `certificateChain` | `byte[]` | `null` | PEM-encoded client certificate chain for mTLS (requires `privateKey`). |
+| `serverNameOverride` | `String` | `null` | Override the hostname used for TLS SNI/verification (useful with self-signed certs). |
 
 ## Message fields
 


### PR DESCRIPTION
## Summary

- **C# (`docs/clients/csharp.md`)**: Adds `QueueTiAuth` recommended auth section with `LoginAsync`/`RefreshAsync` usage, adds `Tls` property to `QueueTiClientOptions` table, adds `## TLS Configuration` section with custom CA / mTLS / server name override examples, and `TlsOptions` field reference
- **Java (`docs/clients/java.md`)**: Adds `tls` field to `ConnectOptions` table, adds `## TLS Configuration` section with four examples (system CAs, custom CA, mTLS, hostname override), and `TlsOptions` builder field reference

Closes #62
Closes #63

## Test plan
- [ ] Verify C# TLS examples compile against the `QueueTi.Client` library
- [ ] Verify Java TLS examples compile against the Java client
- [ ] Check `QueueTiAuth` API names match the C# client implementation