### PR TITLE
fix(ci): pre-build admin UI dist to avoid Docker timeout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -334,7 +334,7 @@ jobs:
         # Reuses the dist/ output from the frontend gate job — no npm or Angular
         # build runs inside Docker. The multi-arch image just copies static files
         # into nginx, so both platforms complete in under 2 minutes.
-        uses: actions/download-artifact@fa0a91b85d4f404e444306234b7b2863adfdf3ab # v4.1.8
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: admin-ui-dist
           path: ui/dist/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,6 +121,13 @@ jobs:
       - name: Run ESLint
         run: npx nx lint
 
+      - name: Upload admin UI dist
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: admin-ui-dist
+          path: ui/dist/
+          retention-days: 1
+
   # ─────────────────────────────────────────────────────────────────────────────
   # Job 1c: Node.js client — build, test, lint (gates the release)
   # Mirrors the node-client job in ci.yml exactly.
@@ -312,7 +319,7 @@ jobs:
   publish-ui-image:
     name: "Docker: Build & push admin UI image"
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 10
     needs: [backend, frontend, node-client, python-client, go-client]
 
     permissions:
@@ -322,6 +329,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Download pre-built admin UI dist
+        # Reuses the dist/ output from the frontend gate job — no npm or Angular
+        # build runs inside Docker. The multi-arch image just copies static files
+        # into nginx, so both platforms complete in under 2 minutes.
+        uses: actions/download-artifact@fa0a91b85d4f404e444306234b7b2863adfdf3ab # v4.1.8
+        with:
+          name: admin-ui-dist
+          path: ui/dist/
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
@@ -347,13 +363,11 @@ jobs:
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
         with:
           context: ./ui
-          file: ./ui/Dockerfile
+          file: ./ui/Dockerfile.release
           push: true
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=ui
-          cache-to: type=gha,mode=max,scope=ui
 
   # ─────────────────────────────────────────────────────────────────────────────
   # Job 3: Publish @queue-ti/client to npm

--- a/ui/.dockerignore
+++ b/ui/.dockerignore
@@ -1,0 +1,5 @@
+node_modules/
+.nx/
+dist/
+.angular/
+coverage/

--- a/ui/Dockerfile.release
+++ b/ui/Dockerfile.release
@@ -1,0 +1,7 @@
+FROM nginx:alpine3.21
+RUN rm /etc/nginx/conf.d/default.conf && \
+    chown -R nginx:nginx /var/cache/nginx /var/run /run
+COPY --chown=nginx:nginx dist/admin-ui/browser /usr/share/nginx/html
+COPY --chown=nginx:nginx nginx.conf /etc/nginx/conf.d/default.conf
+USER nginx
+EXPOSE 80


### PR DESCRIPTION
## Problem

The `publish-ui-image` release job was consistently hitting the 15-minute job timeout because it ran `npm ci` + `npx nx build` inside Docker for **both** `linux/amd64` and `linux/arm64`. Angular build output is pure static HTML/JS/CSS — entirely architecture-independent — so the full build was running twice for no reason.

## Fix

- **`frontend` gate job**: uploads `dist/` as a short-lived artifact (`retention-days: 1`) after the existing build step
- **`publish-ui-image` job**: downloads the pre-built artifact and uses a new `ui/Dockerfile.release` that skips the Node build stage entirely — just copies static files into nginx
- Timeout reduced from 15m → 10m (the job now completes in ~2 minutes)
- Removed the GHA layer cache from this job (no longer needed — nothing is being compiled)

## What stays the same

- `ui/Dockerfile` is unchanged — local `docker build` still works as before
- The nginx config, user, and tag strategy are identical
- Both platforms still get a proper multi-arch manifest

## Test plan
- [ ] Trigger a release tag and verify `publish-ui-image` completes well under 10 minutes
- [ ] Verify the pushed image serves the admin UI correctly