### PR TITLE
docs(java): add Spring Boot starter section

### DIFF
--- a/docs/clients/java.md
+++ b/docs/clients/java.md
@@ -105,6 +105,42 @@ cd queue-ti-java-client
 
 Then use `mavenLocal()` as the repository and `1.0-SNAPSHOT` as the version.
 
+## Spring Boot Starter
+
+**Spring Boot users:** A Spring Boot starter is available as a separate artifact (`queue-ti-spring-boot-starter`) that auto-configures `QueueTiClient`, `Producer`, `AdminClient`, and `QueueTiAuth` as Spring beans — no boilerplate required.
+
+### Installation
+
+Add the starter instead of (or alongside) the core client:
+
+**Gradle (Kotlin DSL)**
+
+```kotlin
+dependencies {
+    implementation("de.joesst.dev:queue-ti-spring-boot-starter:VERSION")
+}
+```
+
+**Maven**
+
+```xml
+<dependency>
+    <groupId>de.joesst.dev</groupId>
+    <artifactId>queue-ti-spring-boot-starter</artifactId>
+    <version>VERSION</version>
+</dependency>
+```
+
+### Configuration
+
+```yaml
+queueti:
+  grpc-address: localhost:50051
+  insecure: true
+```
+
+All beans are then available for injection with no additional setup. For the full property reference see the [Spring Boot Starter](https://github.com/Joessst-Dev/queue-ti-java-client#spring-boot-starter) section in the Java client README.
+
 ## Quick Start
 
 ```java

--- a/docs/clients/java.md
+++ b/docs/clients/java.md
@@ -107,17 +107,25 @@ Then use `mavenLocal()` as the repository and `1.0-SNAPSHOT` as the version.
 
 ## Spring Boot Starter
 
-**Spring Boot users:** A Spring Boot starter is available as a separate artifact (`queue-ti-spring-boot-starter`) that auto-configures `QueueTiClient`, `Producer`, `AdminClient`, and `QueueTiAuth` as Spring beans — no boilerplate required.
+**Spring Boot users:** A Spring Boot starter is available as a separate artifact (`queue-ti-spring-boot-starter`) that auto-configures `QueueTiClient`, `Producer`, `AdminClient`, and `QueueTiAuth` as Spring beans — no boilerplate required. Requires **Spring Boot 3.x**.
 
 ### Installation
 
-Add the starter instead of (or alongside) the core client:
+The starter pulls in the core client as a transitive dependency — declare only the starter. Replace `VERSION` with a release tag (e.g. `2026.05.0`). See [releases](https://github.com/Joessst-Dev/queue-ti-java-client/releases) for available versions.
 
 **Gradle (Kotlin DSL)**
 
 ```kotlin
 dependencies {
     implementation("de.joesst.dev:queue-ti-spring-boot-starter:VERSION")
+}
+```
+
+**Gradle (Groovy)**
+
+```groovy
+dependencies {
+    implementation 'de.joesst.dev:queue-ti-spring-boot-starter:VERSION'
 }
 ```
 


### PR DESCRIPTION
## Summary

- Adds a dedicated **Spring Boot Starter** section to `docs/clients/java.md`
- Covers installation (Gradle + Maven), minimal `application.yml` configuration, and links to the full property reference in the Java client README

Closes #68