### PR TITLE
docs(java): add Spring Integration inbound channel adapter section

### DIFF
--- a/docs/clients/java.md
+++ b/docs/clients/java.md
@@ -151,7 +151,7 @@ All beans are then available for injection with no additional setup. For the ful
 
 ## Spring Integration
 
-`queue-ti-spring-integration` provides `QueueTiInboundChannelAdapter` — a `MessageProducerSupport`-based adapter that consumes a queue-ti topic and publishes messages onto any Spring Integration `MessageChannel`. It plugs directly into `IntegrationFlow` pipelines with no boilerplate consumer loop. The core client is pulled in as a transitive dependency.
+`queue-ti-spring-integration` provides `QueueTiInboundChannelAdapter` — a `MessageProducerSupport`-based adapter that consumes a queue-ti topic and publishes messages onto any Spring Integration `MessageChannel`. It plugs directly into `IntegrationFlow` pipelines with no boilerplate consumer loop. The core client is pulled in as a transitive dependency. Requires **Spring Integration 6.x**.
 
 ### Installation
 
@@ -188,11 +188,11 @@ dependencies {
 ```java
 var adapter = new QueueTiInboundChannelAdapter(client, "orders");
 adapter.setOutputChannel(myChannel);
-adapter.afterPropertiesSet();
-adapter.start();
+adapter.afterPropertiesSet(); // omit when declared as a Spring bean
+adapter.start();              // omit when declared as a Spring bean
 ```
 
-`QueueTiInboundChannelAdapter` implements `SmartLifecycle` — declaring it as a Spring bean lets the context call `start()` and `stop()` automatically.
+`QueueTiInboundChannelAdapter` implements `SmartLifecycle` — declaring it as a Spring bean lets the context call `afterPropertiesSet()`, `start()`, and `stop()` automatically.
 
 ### Acknowledge Modes
 
@@ -207,6 +207,19 @@ adapter.setSettlementTimeout(Duration.ofSeconds(60));
 adapter.setOutputChannel(myChannel);
 ```
 
+Downstream handler example:
+
+```java
+var ack = (QueueTiAcknowledgment) message.getHeaders()
+        .get(QueueTiMessageHeaders.ACKNOWLEDGMENT);
+try {
+    process((byte[]) message.getPayload());
+    ack.acknowledge();
+} catch (Exception e) {
+    ack.nack(e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName());
+}
+```
+
 ### Message Headers
 
 | Constant (`QueueTiMessageHeaders.*`) | Header key | Type | Modes |
@@ -218,7 +231,20 @@ adapter.setOutputChannel(myChannel);
 | `METADATA` | `queueti_metadata` | `Map<String, String>` | AUTO + MANUAL |
 | `ACKNOWLEDGMENT` | `queueti_acknowledgment` | `QueueTiAcknowledgment` | MANUAL only |
 
-For the full reference including `ConsumerOptions` and `IntegrationFlow` examples see the [Spring Integration](https://github.com/Joessst-Dev/queue-ti-java-client#spring-integration) section in the Java client README.
+### Consumer Options
+
+Pass a `ConsumerOptions` instance to configure concurrency, consumer group, or visibility timeout:
+
+```java
+var options = ConsumerOptions.builder()
+        .concurrency(4)
+        .consumerGroup("billing")
+        .build();
+
+var adapter = new QueueTiInboundChannelAdapter(client, "orders", options);
+```
+
+For the full reference including `IntegrationFlow` examples see the [Spring Integration](https://github.com/Joessst-Dev/queue-ti-java-client#spring-integration) section in the Java client README.
 
 ## Quick Start
 

--- a/docs/clients/java.md
+++ b/docs/clients/java.md
@@ -149,6 +149,77 @@ queueti:
 
 All beans are then available for injection with no additional setup. For the full property reference see the [Spring Boot Starter](https://github.com/Joessst-Dev/queue-ti-java-client#spring-boot-starter) section in the Java client README.
 
+## Spring Integration
+
+`queue-ti-spring-integration` provides `QueueTiInboundChannelAdapter` — a `MessageProducerSupport`-based adapter that consumes a queue-ti topic and publishes messages onto any Spring Integration `MessageChannel`. It plugs directly into `IntegrationFlow` pipelines with no boilerplate consumer loop. The core client is pulled in as a transitive dependency.
+
+### Installation
+
+Replace `VERSION` with a release tag (e.g. `2026.05.0`). See [releases](https://github.com/Joessst-Dev/queue-ti-java-client/releases) for available versions.
+
+**Gradle (Kotlin DSL)**
+
+```kotlin
+dependencies {
+    implementation("de.joesst.dev:queue-ti-spring-integration:VERSION")
+}
+```
+
+**Gradle (Groovy)**
+
+```groovy
+dependencies {
+    implementation 'de.joesst.dev:queue-ti-spring-integration:VERSION'
+}
+```
+
+**Maven**
+
+```xml
+<dependency>
+    <groupId>de.joesst.dev</groupId>
+    <artifactId>queue-ti-spring-integration</artifactId>
+    <version>VERSION</version>
+</dependency>
+```
+
+### Quick Start
+
+```java
+var adapter = new QueueTiInboundChannelAdapter(client, "orders");
+adapter.setOutputChannel(myChannel);
+adapter.afterPropertiesSet();
+adapter.start();
+```
+
+`QueueTiInboundChannelAdapter` implements `SmartLifecycle` — declaring it as a Spring bean lets the context call `start()` and `stop()` automatically.
+
+### Acknowledge Modes
+
+**AUTO (default)** — the adapter acks when downstream processing returns normally; any uncaught exception causes a nack.
+
+**MANUAL** — a `QueueTiAcknowledgment` is added to the message headers. Downstream code must call `ack.acknowledge()` or `ack.nack(reason)`. The handler thread blocks until settlement; if settlement does not occur within the configured timeout (default 30s), the message is nacked automatically.
+
+```java
+var adapter = new QueueTiInboundChannelAdapter(client, "orders");
+adapter.setAcknowledgeMode(QueueTiInboundChannelAdapter.AcknowledgeMode.MANUAL);
+adapter.setSettlementTimeout(Duration.ofSeconds(60));
+adapter.setOutputChannel(myChannel);
+```
+
+### Message Headers
+
+| Constant (`QueueTiMessageHeaders.*`) | Header key | Type | Modes |
+|--------------------------------------|-----------|------|-------|
+| `MESSAGE_ID` | `queueti_messageId` | `String` | AUTO + MANUAL |
+| `TOPIC` | `queueti_topic` | `String` | AUTO + MANUAL |
+| `RETRY_COUNT` | `queueti_retryCount` | `int` | AUTO + MANUAL |
+| `CREATED_AT` | `queueti_createdAt` | `Instant` | AUTO + MANUAL |
+| `METADATA` | `queueti_metadata` | `Map<String, String>` | AUTO + MANUAL |
+| `ACKNOWLEDGMENT` | `queueti_acknowledgment` | `QueueTiAcknowledgment` | MANUAL only |
+
+For the full reference including `ConsumerOptions` and `IntegrationFlow` examples see the [Spring Integration](https://github.com/Joessst-Dev/queue-ti-java-client#spring-integration) section in the Java client README.
+
 ## Quick Start
 
 ```java


### PR DESCRIPTION
## Summary

- Adds a `## Spring Integration` section to `docs/clients/java.md` (after the Spring Boot Starter section, before Quick Start)
- Covers installation (Gradle Kotlin/Groovy + Maven), quick start, AUTO vs MANUAL acknowledge modes, and the full message header table
- Links to the full reference in the Java client README for `ConsumerOptions` and `IntegrationFlow` examples

Closes #70